### PR TITLE
Added KJS scripts to init missing recipes

### DIFF
--- a/kubejs/server_scripts/mods/create/crushed_aluminum.js
+++ b/kubejs/server_scripts/mods/create/crushed_aluminum.js
@@ -1,0 +1,19 @@
+//missing crushed aluminum handling
+ServerEvents.recipes(event => {
+  event.smelting('alltheores:aluminum_ingot', 'create:crushed_raw_aluminum').xp(0.1).id('kubejs:create/smelting/aluminum_ingot_from_crushed')
+  event.blasting('alltheores:aluminum_ingot', 'create:crushed_raw_aluminum').xp(0.1).id('kubejs:create/blasting/aluminum_ingot_from_crushed')
+  event.custom({
+    type: 'create:splashing',
+    ingredients: [
+      {
+        'item': 'create:crushed_raw_aluminum'
+      }
+    ],
+    results: [
+      {
+        'count': 9,
+        'item': 'alltheores:aluminum_nugget'
+      }
+    ]
+  }).id('kubejs:create/splashing/crushed_raw_aluminum')
+})

--- a/kubejs/server_scripts/mods/create/crushed_lead.js
+++ b/kubejs/server_scripts/mods/create/crushed_lead.js
@@ -1,0 +1,19 @@
+//missing crushed lead handling
+ServerEvents.recipes(event => {
+  event.smelting('alltheores:lead_ingot', 'create:crushed_raw_lead').xp(0.1).id('kubejs:create/smelting/lead_ingot_from_crushed')
+  event.blasting('alltheores:lead_ingot', 'create:crushed_raw_lead').xp(0.1).id('kubejs:create/blasting/lead_ingot_from_crushed')
+  event.custom({
+    type: 'create:splashing',
+    ingredients: [
+      {
+        'item': 'create:crushed_raw_lead'
+      }
+    ],
+    results: [
+      {
+        'count': 9,
+        'item': 'alltheores:lead_nugget'
+      }
+    ]
+  }).id('kubejs:create/splashing/crushed_raw_lead')
+})

--- a/kubejs/server_scripts/mods/create/crushed_nickel.js
+++ b/kubejs/server_scripts/mods/create/crushed_nickel.js
@@ -1,0 +1,19 @@
+//missing crushed nickel handling
+ServerEvents.recipes(event => {
+  event.smelting('alltheores:nickel_ingot', 'create:crushed_raw_nickel').xp(0.1).id('kubejs:create/smelting/nickel_ingot_from_crushed')
+  event.blasting('alltheores:nickel_ingot', 'create:crushed_raw_nickel').xp(0.1).id('kubejs:create/blasting/nickel_ingot_from_crushed')
+  event.custom({
+    type: 'create:splashing',
+    ingredients: [
+      {
+        'item': 'create:crushed_raw_nickel'
+      }
+    ],
+    results: [
+      {
+        'count': 9,
+        'item': 'alltheores:nickel_nugget'
+      }
+    ]
+  }).id('kubejs:create/splashing/crushed_raw_nickel')
+})

--- a/kubejs/server_scripts/mods/create/crushed_osmium.js
+++ b/kubejs/server_scripts/mods/create/crushed_osmium.js
@@ -1,0 +1,19 @@
+//missing crushed osmium handling
+ServerEvents.recipes(event => {
+    event.smelting('alltheores:osmium_ingot', 'create:crushed_raw_osmium').xp(0.1).id('kubejs:create/smelting/osmium_ingot_from_crushed')
+    event.blasting('alltheores:osmium_ingot', 'create:crushed_raw_osmium').xp(0.1).id('kubejs:create/blasting/osmium_ingot_from_crushed')
+    event.custom({
+      type: 'create:splashing',
+      ingredients: [
+        {
+          'item': 'create:crushed_raw_osmium'
+        }
+      ],
+      results: [
+        {
+          'count': 9,
+          'item': 'alltheores:osmium_nugget'
+        }
+      ]
+    }).id('kubejs:create/splashing/crushed_raw_osmium')
+  })

--- a/kubejs/server_scripts/mods/create/crushed_silver.js
+++ b/kubejs/server_scripts/mods/create/crushed_silver.js
@@ -1,0 +1,19 @@
+//missing crushed silver handling
+ServerEvents.recipes(event => {
+  event.smelting('alltheores:silver_ingot', 'create:crushed_raw_silver').xp(0.1).id('kubejs:create/smelting/silver_ingot_from_crushed')
+  event.blasting('alltheores:silver_ingot', 'create:crushed_raw_silver').xp(0.1).id('kubejs:create/blasting/silver_ingot_from_crushed')
+  event.custom({
+    type: 'create:splashing',
+    ingredients: [
+      {
+        'item': 'create:crushed_raw_silver'
+      }
+    ],
+    results: [
+      {
+        'count': 9,
+        'item': 'alltheores:silver_nugget'
+      }
+    ]
+  }).id('kubejs:create/splashing/crushed_raw_silver')
+})

--- a/kubejs/server_scripts/mods/create/crushed_tin.js
+++ b/kubejs/server_scripts/mods/create/crushed_tin.js
@@ -1,0 +1,19 @@
+//missing crushed tin handling
+ServerEvents.recipes(event => {
+  event.smelting('alltheores:tin_ingot', 'create:crushed_raw_tin').xp(0.1).id('kubejs:create/smelting/tin_ingot_from_crushed')
+  event.blasting('alltheores:tin_ingot', 'create:crushed_raw_tin').xp(0.1).id('kubejs:create/blasting/tin_ingot_from_crushed')
+  event.custom({
+    type: 'create:splashing',
+    ingredients: [
+      {
+        'item': 'create:crushed_raw_tin'
+      }
+    ],
+    results: [
+      {
+        'count': 9,
+        'item': 'alltheores:tin_nugget'
+      }
+    ]
+  }).id('kubejs:create/splashing/crushed_raw_tin')
+})

--- a/kubejs/server_scripts/mods/create/crushed_uranium.js
+++ b/kubejs/server_scripts/mods/create/crushed_uranium.js
@@ -1,0 +1,19 @@
+//missing crushed uranium handling
+ServerEvents.recipes(event => {
+  event.smelting('alltheores:uranium_ingot', 'create:crushed_raw_uranium').xp(0.1).id('kubejs:create/smelting/uranium_ingot_from_crushed')
+  event.blasting('alltheores:uranium_ingot', 'create:crushed_raw_uranium').xp(0.1).id('kubejs:create/blasting/uranium_ingot_from_crushed')
+  event.custom({
+    type: 'create:splashing',
+    ingredients: [
+      {
+        'item': 'create:crushed_raw_uranium'
+      }
+    ],
+    results: [
+      {
+        'count': 9,
+        'item': 'alltheores:uranium_nugget'
+      }
+    ]
+  }).id('kubejs:create/splashing/crushed_raw_uranium')
+})


### PR DESCRIPTION
I have created kjs scripts to add the missing create crushed ore handling, it seems that this has been completed for platinum, but not for any of the other metals. The scripts are exactly the same as the platinum one, just with name changed for retrospective metal. Test on latest version and works. Feel free to look over code and reject if you have other plans.