### PR TITLE
Power Revamp 10-8-23

### DIFF
--- a/config/Mekanism/generators.toml
+++ b/config/Mekanism/generators.toml
@@ -37,9 +37,9 @@
 		tankCapacity = 18000
 		#The number of ticks each mB of Ethylene burns for in the Gas-Burning Generator.
 		#Range: > 1
-		ethyleneBurnTicks = 40
+		ethyleneBurnTicks = 20
 		#Multiplier for calculating the energy density of Ethylene (1 mB Hydrogen + 2 * bioGeneration * densityMultiplier).
-		ethyleneDensityMultiplier = "0.05"
+		ethyleneDensityMultiplier = "0.50"
 
 	#Turbine Settings
 	[generators.turbine]

--- a/config/Mekanism/generators.toml
+++ b/config/Mekanism/generators.toml
@@ -11,7 +11,7 @@
 	#Bio Generator Settings
 	[generators.bio_generator]
 		#Amount of energy in Joules the Bio Generator produces per tick.
-		bioGeneration = "350"
+		bioGeneration = "1250"
 		#The capacity in mB of the fluid tank in the Bio Generator.
 		#Range: > 1
 		tankCapacity = 24000
@@ -39,7 +39,7 @@
 		#Range: > 1
 		ethyleneBurnTicks = 40
 		#Multiplier for calculating the energy density of Ethylene (1 mB Hydrogen + 2 * bioGeneration * densityMultiplier).
-		ethyleneDensityMultiplier = "40"
+		ethyleneDensityMultiplier = "0.05"
 
 	#Turbine Settings
 	[generators.turbine]

--- a/config/extremereactors/common.toml
+++ b/config/extremereactors/common.toml
@@ -27,7 +27,7 @@
 		maxReactorSize = 32
 		#A multiplier for balancing Reactor power production. Stacks with powerProductionMultiplier.
 		#Range: 0.5 ~ 100.0
-		reactorPowerProductionMultiplier = 1.0
+		reactorPowerProductionMultiplier = 3.0
 
 	#Define how Turbines works
 	[common.turbine]

--- a/config/ftbquests/quests/chapters/applied_energistics_2.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.snbt
@@ -2219,9 +2219,9 @@
 		{
 			dependencies: ["2B31E6C1707D8195"]
 			description: [
-				"the &bWireless Terminal&f functions identically to a regular terminal, but wirelessly. Go figure."
+				"The &bWireless Terminal&f functions identically to a regular terminal, but wirelessly."
 				""
-				"Before a wireless terminal can be used to access a network, it must first be &elinked&f to the network via the &eSecurity Terminal&f you made earlier. If it is not linked to a network, or is out of either range or power, the terminal will not function."
+				"Before it can be used to access a network, it must first be &elinked&f to the network by placing it into the top-right slot of the &eWireless Access Point&r. If it is not linked to a network, or is out of either range or power, the terminal will not function."
 				""
 				"Wireless terminals can also be upgraded with &eEnergy Cards&f to provide a larger internal battery."
 			]

--- a/config/ftbquests/quests/chapters/create.snbt
+++ b/config/ftbquests/quests/chapters/create.snbt
@@ -114,9 +114,9 @@
 		{
 			dependencies: ["23A9617F183C4EB1"]
 			description: [
-				"The &n&5Waterwheel&r is one of the most basic ways of generating rotational force. You can hook up multiple wheels by placing them next to each other."
+				"The &n&5Water Wheel&r is one of the most basic ways of generating rotational force. You can hook up multiple wheels by placing them next to each other."
 				""
-				"The speed it's rotating at is measured by how many flowing water blocks are touching the wheel."
+				"You can also change the appearance by using different Wooden Logs on them!"
 			]
 			id: "1AC0B7934F275EDE"
 			rewards: [{

--- a/config/ftbquests/quests/chapters/mystical_ag.snbt
+++ b/config/ftbquests/quests/chapters/mystical_ag.snbt
@@ -2743,7 +2743,7 @@
 		}
 		{
 			dependencies: ["66C52B137A4FF869"]
-			hide: true
+			hide: false
 			hide_dependency_lines: true
 			id: "67DBE6C59C0D9D1B"
 			rewards: [
@@ -3552,7 +3552,7 @@
 				"33D23C65E7274A8F"
 				"1CF8263756EE8F2A"
 			]
-			hide: true
+			hide: false
 			hide_dependency_lines: false
 			icon: "mysticalagriculture:awakened_supremium_essence"
 			id: "7A103577EAE7B3F1"
@@ -3660,7 +3660,6 @@
 		{
 			dependencies: ["67DBE6C59C0D9D1B"]
 			description: ["This special &eDust&r is dropped from the Wither and the Ender Dragon when killed by an &dEssence Weapon&r enchanted with &dMystical Enlightenment&r."]
-			hide: true
 			hide_dependency_lines: false
 			id: "1CF8263756EE8F2A"
 			rewards: [

--- a/config/ftbquests/quests/chapters/occultism.snbt
+++ b/config/ftbquests/quests/chapters/occultism.snbt
@@ -1048,8 +1048,8 @@
 				xp: 25
 			}]
 			tasks: [{
-				id: "06129887D34EB9AA"
-				item: "occultism:raw_iesnium"
+				id: "2C341B16967645C9"
+				item: "occultism:iesnium_ore"
 				type: "item"
 			}]
 			title: "&cIesnium: Ore of the Otherworld&r"

--- a/config/ftbquests/quests/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/chapters/productive_bees.snbt
@@ -405,7 +405,7 @@
 		}
 		{
 			dependencies: ["120BDCB70AD352AC"]
-			description: ["When placed in the Nether, the Glowstone Nest will lure in a Glowing Bee."]
+			description: ["When placed in the Nether and given Glowstone, the Glowstone Nest will lure in a Glowing Bee."]
 			hide: false
 			hide_dependency_lines: true
 			id: "41CF7CAEE4F60CCD"
@@ -433,7 +433,7 @@
 				type: "xp"
 				xp: 10
 			}]
-			subtitle: "Lures in Ghostly Bees when placed in the Nether"
+			subtitle: "Lures in Ghostly Bees when placed in the Nether and given Ghast Tears"
 			tasks: [{
 				id: "432B3806B0D8F356"
 				item: "productivebees:soul_sand_nest"
@@ -445,7 +445,7 @@
 		{
 			dependencies: ["120BDCB70AD352AC"]
 			description: [
-				"This nest attracts &eCrystalline Bees&r."
+				"This nest attracts &eCrystalline Bees&r. You'll need Nether Quartz instead of using Honey Treats to attract the Bee."
 				""
 				"The easiest way to get a quartz block is by mining it with a Silk Touch pick."
 				""
@@ -470,7 +470,7 @@
 		}
 		{
 			dependencies: ["120BDCB70AD352AC"]
-			description: ["Placing the Nether Brick Nest in the Nether will lure in a Magmatic Bee."]
+			description: ["Placing the Nether Brick Nest in the Nether will lure in a Magmatic Bee when given Magma Cream."]
 			hide: false
 			hide_dependency_lines: true
 			id: "349D19F2FCC34B84"
@@ -490,6 +490,7 @@
 		}
 		{
 			dependencies: ["120BDCB70AD352AC"]
+			description: ["To attract Bees to this nest, you'll need Popped Chorus Fruit instead of Honey Treats."]
 			hide: false
 			hide_dependency_lines: true
 			id: "1E9BD4B74DAEA9FC"
@@ -509,7 +510,11 @@
 		}
 		{
 			dependencies: ["120BDCB70AD352AC"]
-			description: ["The Obsidian Nest will lure in Draconic Bees when placed in the End."]
+			description: [
+				"The Obsidian Nest will lure in Draconic Bees when placed in the End."
+				""
+				"These do not accept Honey Treats, but instead use Dragon's Breath."
+			]
 			hide: false
 			hide_dependency_lines: true
 			id: "3155E4212045BC8E"
@@ -831,7 +836,7 @@
 				""
 				"Instead, you spawn them using Nests with &6Honey Treats&r."
 				""
-				"With these, you'll create yourself some Nests and right click them with the treats to lure Bees in."
+				"With these, you'll create yourself some Nests and right click them with the treats to lure Bees in. Some Nests require special items instead of Honey Treats, so make sure to check JEI for more info!"
 				""
 				"Make sure to check out which biome you need to be in to lure in the right bees!"
 			]
@@ -937,7 +942,7 @@
 				}
 			]
 			shape: "hexagon"
-			subtitle: "Increases Bee Productivity by 140%"
+			subtitle: "Increases Bee Productivity by 120%"
 			tasks: [{
 				id: "23697EE31757EBEB"
 				item: "productivebees:upgrade_productivity"
@@ -1140,9 +1145,11 @@
 		{
 			dependencies: ["7C169A4A39F37FAC"]
 			description: [
-				"While you can definitely just use a regular &9Centrifuge&r in the beginning, getting a &6Powered Centrifuge&r soon after is a must."
+				"The &9Centrifuge&r is used to process Combs from Bees into useful items and honey! While you can definitely just use a regular &9Centrifuge&r in the beginning, getting a &6Powered Centrifuge&r soon after is a must. This is a faster Centrifuge that runs off of power!"
 				""
-				"The Centrifuge is used to process Honeycombs into useful items, honey, and wax."
+				"If you're looking for the best way to process your Combs, the &cHeated Centrifuge&r is even faster and can even process &aComb Blocks&r!"
+				""
+				"These can all be made faster by using Speed Upgrades."
 			]
 			id: "33A0E06FE5CFD8F3"
 			rewards: [
@@ -1161,8 +1168,28 @@
 			]
 			subtitle: "Processing Honeycombs"
 			tasks: [{
-				id: "01233EB4BF20A278"
-				item: "productivebees:powered_centrifuge"
+				id: "65D52E6A67DD11EB"
+				item: {
+					Count: 1b
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "productivebees:centrifuge"
+							}
+							{
+								Count: 1b
+								id: "productivebees:powered_centrifuge"
+							}
+							{
+								Count: 1b
+								id: "productivebees:heated_centrifuge"
+							}
+						]
+					}
+				}
+				title: "Centrifuges"
 				type: "item"
 			}]
 			x: 0.0d
@@ -2822,15 +2849,9 @@
 			}]
 			subtitle: "Yellow + Green Carpenter Bee"
 			tasks: [{
-				id: "5569927ACA7F6486"
-				item: {
-					Count: 1b
-					id: "productivebees:wood_chip"
-					tag: {
-						productivebees_woodtype: "minecraft:dark_oak_log"
-					}
-				}
-				type: "item"
+				id: "6047113DC2263E46"
+				title: "Lumber Bee"
+				type: "checkmark"
 			}]
 			title: "Lumber Bee"
 			x: 3.0d
@@ -3048,22 +3069,9 @@
 			}]
 			subtitle: "Chocolate Mining + Digger"
 			tasks: [{
-				icon: {
-					Count: 1b
-					id: "productivebees:stone_chip"
-					tag: {
-						productivebees_woodtype: "minecraft:dirt"
-					}
-				}
-				id: "25C3E86C4FE954C6"
-				item: {
-					Count: 1b
-					id: "productivebees:stone_chip"
-					tag: {
-						productivebees_woodtype: "minecraft:dirt"
-					}
-				}
-				type: "item"
+				id: "471F062B01D0DDA1"
+				title: "Quarry Bee"
+				type: "checkmark"
 			}]
 			title: "Quarry Bee"
 			x: 0.0d
@@ -4265,6 +4273,7 @@
 		}
 		{
 			dependencies: ["120BDCB70AD352AC"]
+			description: ["Instead of using Honey Treats, this hive requires Gold Ingots to attract Bees."]
 			hide_dependency_lines: true
 			id: "160BD0185954C891"
 			rewards: [{
@@ -4280,6 +4289,78 @@
 			}]
 			x: -9.0d
 			y: 4.5d
+		}
+		{
+			dependencies: ["6DBF9CAB37B9BBF3"]
+			id: "01A0612C516B4F7F"
+			rewards: [
+				{
+					id: "78311D0F7C60994E"
+					type: "xp"
+					xp: 25
+				}
+				{
+					exclude_from_claim_all: true
+					id: "53466516293198D5"
+					table_id: 4196188979167302596L
+					type: "random"
+				}
+			]
+			tasks: [{
+				id: "123810EB2AEB0EAB"
+				item: "productivebees:upgrade_productivity_2"
+				type: "item"
+			}]
+			x: -6.0d
+			y: 0.5d
+		}
+		{
+			dependencies: ["01A0612C516B4F7F"]
+			id: "58ACADCBA57BC1DB"
+			rewards: [
+				{
+					id: "0156FA9A01DFAC03"
+					type: "xp"
+					xp: 25
+				}
+				{
+					exclude_from_claim_all: true
+					id: "7DFAC9BC1DF0F99D"
+					table_id: 4196188979167302596L
+					type: "loot"
+				}
+			]
+			tasks: [{
+				id: "0F962A0E762836D4"
+				item: "productivebees:upgrade_productivity_3"
+				type: "item"
+			}]
+			x: -7.0d
+			y: 0.5d
+		}
+		{
+			dependencies: ["58ACADCBA57BC1DB"]
+			id: "4DDF647FE6494DE1"
+			rewards: [
+				{
+					id: "78E6295E2CD504BD"
+					type: "xp"
+					xp: 50
+				}
+				{
+					exclude_from_claim_all: true
+					id: "7C1C2FCB825216F2"
+					table_id: 5564196992594175882L
+					type: "loot"
+				}
+			]
+			tasks: [{
+				id: "3FD59559C494AE6B"
+				item: "productivebees:upgrade_productivity_4"
+				type: "item"
+			}]
+			x: -8.0d
+			y: 0.5d
 		}
 	]
 	title: "Productive Bees"

--- a/config/ftbquests/quests/reward_tables/Tier3_Seed Bag.snbt
+++ b/config/ftbquests/quests/reward_tables/Tier3_Seed Bag.snbt
@@ -2,7 +2,7 @@
 	icon: "mysticalagriculture:tertium_gemstone"
 	id: "6B7F78B9150AFFEE"
 	loot_size: 1
-	order_index: 17
+	order_index: 20
 	rewards: [
 		{ item: "mysticalagriculture:tertium_farmland", weight: 5.0f }
 		{ item: "mysticalagriculture:iron_seeds", weight: 2.0f }
@@ -23,9 +23,6 @@
 		{ item: "mysticalagriculture:creeper_seeds" }
 		{ item: "mysticalagriculture:skeleton_seeds", weight: 3.0f }
 		{ item: "mysticalagriculture:lead_seeds", weight: 3.0f }
-		{ item: "mysticalagriculture:blizz_seeds" }
-		{ item: "mysticalagriculture:blitz_seeds" }
-		{ item: "mysticalagriculture:basalz_seeds" }
 		{ item: "mysticalagriculture:certus_quartz_seeds", weight: 2.0f }
 		{ item: "mysticalagriculture:quartz_enriched_iron_seeds" }
 		{ item: "mysticalagriculture:no_fall_damage_augment" }

--- a/config/ftbquests/quests/reward_tables/common.snbt
+++ b/config/ftbquests/quests/reward_tables/common.snbt
@@ -8,7 +8,7 @@
 	}
 	id: "06C4634E81851A6C"
 	loot_size: 1
-	order_index: 9
+	order_index: 12
 	rewards: [
 		{ item: "botanypots:terracotta_hopper_botany_pot", weight: 5.0f }
 		{ item: "mysticalagriculture:imperium_essence" }
@@ -314,26 +314,36 @@
 		{ item: "ae2:flawless_budding_quartz" }
 		{
 			command: "/sgear_random_gear @p silentgear:hammer 2"
+			elevate_perms: true
+			silent: true
 			type: "command"
 			weight: 5.0f
 		}
 		{
 			command: "/sgear_random_gear @p silentgear:hammer 3"
+			elevate_perms: true
+			silent: true
 			type: "command"
 			weight: 3.0f
 		}
 		{
 			command: "/sgear_random_gear @p silentgear:pickaxe 2"
+			elevate_perms: true
+			silent: true
 			type: "command"
 			weight: 7.0f
 		}
 		{
 			command: "/sgear_random_gear @p silentgear:pickaxe 3"
+			elevate_perms: true
+			silent: true
 			type: "command"
 			weight: 5.0f
 		}
 		{
 			command: "/sgear_random_gear @p silentgear:paxel 3"
+			elevate_perms: true
+			silent: true
 			type: "command"
 			weight: 3.0f
 		}

--- a/config/generatorgalore/defaults.lock
+++ b/config/generatorgalore/defaults.lock
@@ -1,0 +1,1 @@
+This lock file means the standard generators have already been added and you can now do your own custom stuff to them.

--- a/config/generatorgalore/generators/copper.json
+++ b/config/generatorgalore/generators/copper.json
@@ -1,0 +1,7 @@
+{
+  "generationRate": 20,
+  "transferRate": 40,
+  "consumptionRate": 1.2,
+  "bufferCapacity": 5000,
+  "fuelType": "SOLID"
+}

--- a/config/generatorgalore/generators/culinary.json
+++ b/config/generatorgalore/generators/culinary.json
@@ -1,0 +1,8 @@
+{
+  "generationRate": 10,
+  "transferRate": 512,
+  "consumptionRate": 1,
+  "previousTier": "gold",
+  "bufferCapacity": 100000,
+  "fuelType": "FOOD"
+}

--- a/config/generatorgalore/generators/diamond.json
+++ b/config/generatorgalore/generators/diamond.json
@@ -1,0 +1,8 @@
+{
+  "generationRate": 160,
+  "transferRate": 512,
+  "consumptionRate": 0.6,
+  "previousTier": "gold",
+  "bufferCapacity": 100000,
+  "fuelType": "SOLID"
+}

--- a/config/generatorgalore/generators/emerald.json
+++ b/config/generatorgalore/generators/emerald.json
@@ -1,0 +1,8 @@
+{
+  "generationRate": 300,
+  "transferRate": 1200,
+  "consumptionRate": 0.4,
+  "previousTier": "diamond",
+  "bufferCapacity": 500000,
+  "fuelType": "SOLID"
+}

--- a/config/generatorgalore/generators/enchantment.json
+++ b/config/generatorgalore/generators/enchantment.json
@@ -1,0 +1,8 @@
+{
+  "generationRate": 500,
+  "transferRate": 1024,
+  "consumptionRate": 1,
+  "previousTier": "obsidian",
+  "bufferCapacity": 1000000,
+  "fuelType": "ENCHANTMENT"
+}

--- a/config/generatorgalore/generators/ender.json
+++ b/config/generatorgalore/generators/ender.json
@@ -1,0 +1,18 @@
+{
+  "generationRate": 300,
+  "transferRate": 1200,
+  "consumptionRate": 1,
+  "previousTier": "obsidian",
+  "bufferCapacity": 500000,
+  "fuelList": [
+    {
+      "item": "minecraft:ender_pearl",
+      "burnTime": 1600
+    },
+    {
+      "item": "minecraft:ender_eye",
+      "rate": 500,
+      "burnTime": 3200
+    }
+  ]
+}

--- a/config/generatorgalore/generators/gold.json
+++ b/config/generatorgalore/generators/gold.json
@@ -1,0 +1,8 @@
+{
+  "generationRate": 80,
+  "transferRate": 160,
+  "consumptionRate": 0.8,
+  "previousTier": "iron",
+  "bufferCapacity": 30000,
+  "fuelType": "SOLID"
+}

--- a/config/generatorgalore/generators/halitosis.json
+++ b/config/generatorgalore/generators/halitosis.json
@@ -1,0 +1,14 @@
+{
+  "generationRate": 1000,
+  "transferRate": 16384,
+  "consumptionRate": 1,
+  "previousTier": "ender",
+  "bufferCapacity": 9800000,
+  "fuelType": "SOLID",
+  "fuelList": [
+    {
+      "item": "minecraft:dragon_breath",
+      "burnTime": 200
+    }
+  ]
+}

--- a/config/generatorgalore/generators/iron.json
+++ b/config/generatorgalore/generators/iron.json
@@ -1,0 +1,8 @@
+{
+  "generationRate": 40,
+  "transferRate": 160,
+  "consumptionRate": 1,
+  "previousTier": "copper",
+  "bufferCapacity": 10000,
+  "fuelType": "SOLID"
+}

--- a/config/generatorgalore/generators/magmatic.json
+++ b/config/generatorgalore/generators/magmatic.json
@@ -1,0 +1,9 @@
+{
+  "generationRate": 150,
+  "transferRate": 600,
+  "consumptionRate": 0.4,
+  "previousTier": "obsidian",
+  "bufferCapacity": 500000,
+  "fuelType": "FLUID",
+  "fuelTag": "minecraft:lava"
+}

--- a/config/generatorgalore/generators/netherite.json
+++ b/config/generatorgalore/generators/netherite.json
@@ -1,0 +1,8 @@
+{
+  "generationRate": 500,
+  "transferRate": 2048,
+  "consumptionRate": 0.4,
+  "previousTier": "diamond",
+  "bufferCapacity": 1000000,
+  "fuelType": "SOLID"
+}

--- a/config/generatorgalore/generators/netherstar.json
+++ b/config/generatorgalore/generators/netherstar.json
@@ -1,0 +1,9 @@
+{
+  "generationRate": 10000,
+  "transferRate": 40000,
+  "consumptionRate": 2400,
+  "previousTier": "netherite",
+  "bufferCapacity": 9800000,
+  "fuelType": "SOLID",
+  "fuelTag": "forge:nether_stars"
+}

--- a/config/generatorgalore/generators/obsidian.json
+++ b/config/generatorgalore/generators/obsidian.json
@@ -1,0 +1,8 @@
+{
+  "generationRate": 200,
+  "transferRate": 800,
+  "consumptionRate": 0.6,
+  "previousTier": "diamond",
+  "bufferCapacity": 500000,
+  "fuelType": "SOLID"
+}

--- a/config/generatorgalore/generators/potion.json
+++ b/config/generatorgalore/generators/potion.json
@@ -1,0 +1,8 @@
+{
+  "generationRate": 16,
+  "transferRate": 512,
+  "consumptionRate": 1,
+  "previousTier": "culinary",
+  "bufferCapacity": 250000,
+  "fuelType": "POTION"
+}

--- a/config/powah.json5
+++ b/config/powah.json5
@@ -18,7 +18,8 @@
 		"lens_of_ender": true,
 		// List of fluids used in the Magmator.
 		"magmatic_fluids": {
-			"minecraft:lava": 10000
+			"minecraft:lava": 10000,
+			"allthemodium:soul_lava": 90000
 		},
 		// List of coolant fluids used in the Reactor and the Thermo Generator.
 		"coolant_fluids": {
@@ -26,9 +27,9 @@
 		},
 		// List of heat source blocks used under Thermo Generator.
 		"heat_blocks": {
+			"minecraft:lava": 1000,
 			"minecraft:magma_block": 800,
 			"powah:blazing_crystal_block": 2800,
-			"minecraft:lava": 1000,
 			"allthemodium:soul_lava": 9000
 		},
 		// Energy produced per fuel tick in the Furnator.
@@ -52,19 +53,19 @@
 				"nitro": 40000000
 			},
 			"transfer_rates": {
-				"starter": 80,
-				"basic": 320,
-				"hardened": 800,
-				"blazing": 3200,
+				"starter": 240,
+				"basic": 480,
+				"hardened": 1600,
+				"blazing": 4000,
 				"niotic": 8000,
 				"spirited": 32000,
 				"nitro": 160000
 			},
 			"generation_rates": {
-				"starter": 20,
-				"basic": 80,
-				"hardened": 200,
-				"blazing": 800,
+				"starter": 80,
+				"basic": 160,
+				"hardened": 400,
+				"blazing": 1000,
 				"niotic": 2000,
 				"spirited": 8000,
 				"nitro": 20000
@@ -81,19 +82,19 @@
 				"nitro": 40000000
 			},
 			"transfer_rates": {
-				"starter": 80,
-				"basic": 320,
-				"hardened": 800,
-				"blazing": 3200,
+				"starter": 240,
+				"basic": 480,
+				"hardened": 1600,
+				"blazing": 4000,
 				"niotic": 8000,
 				"spirited": 32000,
 				"nitro": 160000
 			},
 			"generation_rates": {
-				"starter": 20,
-				"basic": 80,
-				"hardened": 200,
-				"blazing": 800,
+				"starter": 80,
+				"basic": 160,
+				"hardened": 400,
+				"blazing": 1000,
 				"niotic": 2000,
 				"spirited": 8000,
 				"nitro": 20000
@@ -139,22 +140,22 @@
 				"nitro": 40000000
 			},
 			"transfer_rates": {
-				"starter": 80,
-				"basic": 320,
-				"hardened": 800,
-				"blazing": 3200,
-				"niotic": 8000,
-				"spirited": 32000,
-				"nitro": 160000
+				"starter": 160,
+				"basic": 480,
+				"hardened": 1600,
+				"blazing": 6000,
+				"niotic": 20000,
+				"spirited": 64000,
+				"nitro": 200000
 			},
 			"generation_rates": {
-				"starter": 20,
-				"basic": 60,
-				"hardened": 180,
-				"blazing": 540,
-				"niotic": 1620,
-				"spirited": 5000,
-				"nitro": 20000
+				"starter": 40,
+				"basic": 120,
+				"hardened": 400,
+				"blazing": 1500,
+				"niotic": 5000,
+				"spirited": 16000,
+				"nitro": 50000
 			}
 		},
 		"thermo_generators": {
@@ -168,7 +169,7 @@
 				"nitro": 40000000
 			},
 			"transfer_rates": {
-				"starter": 80,
+				"starter": 160,
 				"basic": 320,
 				"hardened": 800,
 				"blazing": 3200,
@@ -177,13 +178,13 @@
 				"nitro": 160000
 			},
 			"generation_rates": {
-				"starter": 20,
-				"basic": 60,
-				"hardened": 100,
-				"blazing": 200,
-				"niotic": 400,
-				"spirited": 800,
-				"nitro": 2000
+				"starter": 40,
+				"basic": 80,
+				"hardened": 150,
+				"blazing": 300,
+				"niotic": 600,
+				"spirited": 1500,
+				"nitro": 3500
 			}
 		}
 	},

--- a/kubejs/server_scripts/mods/mekanism/mekanism.js
+++ b/kubejs/server_scripts/mods/mekanism/mekanism.js
@@ -20,10 +20,25 @@ ServerEvents.recipes(e => {
   // remove combiner recipes for ores
   e.remove({ type: 'mekanism:combining', id: /ore/ })
   // delete ethylene
+  /*
   e.remove({ id: 'mekanism:reaction/substrate/water_hydrogen'})
   e.remove({ id: 'mekanism:reaction/substrate/ethene_oxygen'})
   e.remove({ id: 'mekanism:reaction/substrate/water_ethene'})
+  */
+  
+  // GBG Recipe Change | Alfred
+  e.remove({ id: 'mekanismgenerators:generator/gas_burning' })
+  e.shaped( 'mekanismgenerators:gas_burning_generator', ['UBU', 'TDT', 'UBU'], {
+	U: 'mekanism:ingot_refined_obsidian',
+    B: 'mekanism:alloy_atomic',
+    T: 'mekanismgenerators:bio_generator',
+    D: 'mekanism:electrolytic_core'
+  }).id('kubejs:mekanismgenerators/gas_burning_gen')
+  
+  
   //substrate
+  
+  /*
   e.custom({
     "type": "mekanism:reaction",
     "duration": 100,
@@ -93,5 +108,5 @@ ServerEvents.recipes(e => {
     "itemOutput": {
       "item": "mekanism:hdpe_pellet"
     }
-  })
+  }) */
 })


### PR DESCRIPTION
- Extreme Reactors now produce 3x the power
- Generator Galore generators have been buffed across the board.
- Gas-Burning-Generator makes its return. The recipe is a little harder, and overall output of power has been nerfed by a lot. This will be monitored to see if it's too much of a nerf.
- The Bio Gen in Mek has been buffed to ~500 RF/t.
- Most early game Powah generators have been buffed.
- You can now use Soul Lava in Magmators. It will not produce more RF/t, but will generate 9x the total RF per mb.

Complete list of changes will be made available in discord.