### PR TITLE
Add recipes for the infused teleportation cores

### DIFF
--- a/kubejs/server_scripts/modpack/mini_portals.js
+++ b/kubejs/server_scripts/modpack/mini_portals.js
@@ -53,35 +53,24 @@ ServerEvents.recipes(event => {
 
   }).id('kubejs:allthetweaks/mini_nether')
 
-/*  
 // Nether Infused Teleportation Core
-	event.custom({
-  "type": "elementalcraft:binding",
-  "element_amount": 10000,
-  "element_type": "fire",
-  "ingredients": [
-    {
-      "item": "mekanism:teleportation_core"
+  event.custom({
+    type: "apotheosis:enchanting",
+    input: {
+      item: "mekanism:teleportation_core"
     },
-	{
-      "item": "elementalcraft:purecrystal"
+    requirements: {
+      eterna: 40,
+      quanta: 15,
+      arcana: 60
     },
-	{
-      "item": "minecraft:netherite_block"
+    max_requirements: {
+      eterna: -1,
+      quanta: 25,
+      arcana: -1
     },
-    
-	Item.of('elementalcraft:jewel', '{elementalcraft:{jewel:"elementalcraft:piglin"}}').strongNBT().toJson(),
-    
-    {
-      "item": "minecraft:netherite_block"
-    },
-    {
-      "item": "elementalcraft:purecrystal"
-    }
-  ],
-  "output": Item.of('mekanism:teleportation_core', "{HideFlags:1,display:{Name:'[{\"text\":\"Nether Infused Teleportation Core\",\"italic\":false}]'}}").enchant('unbreaking', 1).toJson()
-}).id('kubejs:allthetweaks/nether_core')
-*/
+    result: Item.of('mekanism:teleportation_core', "{HideFlags:1,display:{Name:'[{\"text\":\"Nether Infused Teleportation Core\",\"italic\":false}]'}}").enchant('unbreaking', 1).toJson()
+  }).id("kubejs:allthetweaks/nether_core")
   
   // Mini End
 	event.shaped('allthetweaks:mini_end', ['ABA', 'BCB', 'ABA'], {
@@ -91,35 +80,24 @@ ServerEvents.recipes(event => {
 
   }).id('kubejs:allthetweaks/mini_end')
 
-/*
 // Ender Infused Teleportation Core
-	event.custom({
-  "type": "elementalcraft:binding",
-  "element_amount": 10000,
-  "element_type": "air",
-  "ingredients": [
-    {
-      "item": "mekanism:teleportation_core"
-    },
-	{
-      "item": "elementalcraft:purecrystal"
-    },
-	{
-      "item": "allthetweaks:ender_pearl_block"
-    },
-    
-	Item.of('elementalcraft:jewel', '{elementalcraft:{jewel:"elementalcraft:demigod"}}').strongNBT().toJson(),
-    
-    {
-      "item": "allthetweaks:ender_pearl_block"
-    },
-    {
-      "item": "elementalcraft:purecrystal"
-    }
-  ],
-  "output": Item.of('mekanism:teleportation_core', "{HideFlags:1,display:{Name:'[{\"text\":\"Ender Infused Teleportation Core\",\"italic\":false}]'}}").enchant('unbreaking', 1).toJson()
-}).id('kubejs:allthetweaks/ender_core')
-*/
+event.custom({
+  type: "apotheosis:enchanting",
+  input: {
+    item: "mekanism:teleportation_core"
+  },
+  requirements: {
+    eterna: 50,
+    quanta: 8.5,
+    arcana: 32.5
+  },
+  max_requirements: {
+    eterna: 50,
+    quanta: 13.5,
+    arcana: 37.5
+  },
+  result: Item.of('mekanism:teleportation_core', "{HideFlags:1,display:{Name:'[{\"text\":\"Ender Infused Teleportation Core\",\"italic\":false}]'}}").enchant('unbreaking', 1).toJson()
+}).id("kubejs:allthetweaks/ender_core")
   
 // Mini Exit
 	event.shaped('allthetweaks:mini_exit', ['ABA', 'DCD', 'ADA'], {
@@ -130,34 +108,23 @@ ServerEvents.recipes(event => {
 
   }).id('kubejs:allthetweaks/mini_exit')
  
-/*
 // Draconic Infused Teleportation Core
-	event.custom({
-  "type": "elementalcraft:binding",
-  "element_amount": 10000,
-  "element_type": "fire",
-  "ingredients": [
-    {
-      "item": "mekanism:teleportation_core"
-    },
-	{
-      "item": "elementalcraft:purecrystal"
-    },
-	{
-      "item": "minecraft:dragon_egg"
-    },
-    
-	Item.of('elementalcraft:jewel', '{elementalcraft:{jewel:"elementalcraft:phoenix"}}').strongNBT().toJson(),
-    
-    {
-      "item": "minecraft:dragon_egg"
-    },
-    {
-      "item": "elementalcraft:purecrystal"
-    }
-  ],
-  "output": Item.of('mekanism:teleportation_core', "{HideFlags:1,display:{Name:'[{\"text\":\"Draconic Infused Teleportation Core\",\"italic\":false}]'}}").enchant('unbreaking', 1).toJson()
-}).id('kubejs:allthetweaks/draco_core')
-*/
+event.custom({
+  type: "apotheosis:enchanting",
+  input: {
+    item: "mekanism:teleportation_core"
+  },
+  requirements: {
+    eterna: 50,
+    quanta: 45,
+    arcana: 100
+  },
+  max_requirements: {
+    eterna: 50,
+    quanta: 50,
+    arcana: 100
+  },
+  result: Item.of('mekanism:teleportation_core', "{HideFlags:1,display:{Name:'[{\"text\":\"Draconic Infused Teleportation Core\",\"italic\":false}]'}}").enchant('unbreaking', 1).toJson()
+}).id("kubejs:allthetweaks/draco_core")
   
 })


### PR DESCRIPTION
Uses Apotheosis Infusion Enchanting to take a teleportation core and make it into the different types of infused teleportation core