### PR TITLE
Utilize JsonThings to register AllTheModium ore Mekansim slurries

### DIFF
--- a/thingpacks/allthemodium/pack.mcmeta
+++ b/thingpacks/allthemodium/pack.mcmeta
@@ -1,0 +1,8 @@
+{
+    "pack": {
+        "description": "AllTheModium ThingPack",
+        "pack_format": 13,
+        "forge:assets_pack_format": 13,
+        "forge:data_pack_format": 12
+    }
+}

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_allthemodium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_allthemodium.json
@@ -1,6 +1,6 @@
 {
 
- "tint": "#FFFF3e",
+ "tint": "#ffc70c",
  "clean": true,
  "ore": "forge:ores/allthemodium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_allthemodium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_allthemodium.json
@@ -1,0 +1,6 @@
+{
+
+ "tint": "#FFFFFF",
+ "clean": true,
+ "ore": "forge:ores/allthemodium"
+}

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_allthemodium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_allthemodium.json
@@ -1,6 +1,6 @@
 {
 
- "tint": "#FFFFFF",
+ "tint": "#FFFF3e",
  "clean": true,
  "ore": "forge:ores/allthemodium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_unobtainium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_unobtainium.json
@@ -1,6 +1,6 @@
 {
 
- "tint": "#FFFFFF",
+ "tint": "#ea84f5",
  "clean": true,
  "ore": "forge:ores/allthemodium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_unobtainium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_unobtainium.json
@@ -1,0 +1,6 @@
+{
+
+ "tint": "#FFFFFF",
+ "clean": true,
+ "ore": "forge:ores/allthemodium"
+}

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_unobtainium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_unobtainium.json
@@ -2,5 +2,5 @@
 
  "tint": "#ea84f5",
  "clean": true,
- "ore": "forge:ores/allthemodium"
+ "ore": "forge:ores/unobtainium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_vibranium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_vibranium.json
@@ -1,6 +1,6 @@
 {
 
- "tint": "#FFFFFF",
+ "tint": "#26de88",
  "clean": true,
  "ore": "forge:ores/allthemodium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_vibranium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_vibranium.json
@@ -1,0 +1,6 @@
+{
+
+ "tint": "#FFFFFF",
+ "clean": true,
+ "ore": "forge:ores/allthemodium"
+}

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_vibranium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/clean_vibranium.json
@@ -2,5 +2,5 @@
 
  "tint": "#26de88",
  "clean": true,
- "ore": "forge:ores/allthemodium"
+ "ore": "forge:ores/vibranium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_allthemodium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_allthemodium.json
@@ -1,0 +1,6 @@
+{
+
+ "tint": "#FFFFFF",
+ "clean": false,
+ "ore": "forge:ores/allthemodium"
+}

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_allthemodium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_allthemodium.json
@@ -1,6 +1,6 @@
 {
 
- "tint": "#FFFFFF",
+ "tint": "#FFFF3e",
  "clean": false,
  "ore": "forge:ores/allthemodium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_allthemodium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_allthemodium.json
@@ -1,6 +1,6 @@
 {
 
- "tint": "#FFFF3e",
+ "tint": "#ffc70c",
  "clean": false,
  "ore": "forge:ores/allthemodium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_unobtainium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_unobtainium.json
@@ -1,0 +1,6 @@
+{
+
+ "tint": "#FFFFFF",
+ "clean": false,
+ "ore": "forge:ores/allthemodium"
+}

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_unobtainium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_unobtainium.json
@@ -1,6 +1,6 @@
 {
 
- "tint": "#FFFFFF",
+ "tint": "#ea84f5",
  "clean": false,
  "ore": "forge:ores/allthemodium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_unobtainium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_unobtainium.json
@@ -2,5 +2,5 @@
 
  "tint": "#ea84f5",
  "clean": false,
- "ore": "forge:ores/allthemodium"
+ "ore": "forge:ores/unobtainium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_vibranium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_vibranium.json
@@ -1,0 +1,6 @@
+{
+
+ "tint": "#FFFFFF",
+ "clean": false,
+ "ore": "forge:ores/allthemodium"
+}

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_vibranium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_vibranium.json
@@ -1,6 +1,6 @@
 {
 
- "tint": "#FFFFFF",
+ "tint": "#26de88",
  "clean": false,
  "ore": "forge:ores/allthemodium"
 }

--- a/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_vibranium.json
+++ b/thingpacks/allthemodium/things/allthemodium/mekanism/slurry/dirty_vibranium.json
@@ -2,5 +2,5 @@
 
  "tint": "#26de88",
  "clean": false,
- "ore": "forge:ores/allthemodium"
+ "ore": "forge:ores/vibranium"
 }


### PR DESCRIPTION
Fix for https://github.com/AllTheMods/ATM-9/issues/695

To enable AllTheModium ore Mekansim slurry recipes, use these JSONs with mod JsonThings-1.20.1-0.9.1 to register the slurry recipes that already exist in AllTheModium.

Built using docs here: https://github.com/mekanism/Mekanism/wiki/JsonThings-Integration