### PR TITLE
add tech processing lines to make nether stars

### DIFF
--- a/kubejs/assets/gtceu/lang/en_us.json
+++ b/kubejs/assets/gtceu/lang/en_us.json
@@ -1,4 +1,5 @@
 {
     "block.gtceu.star_forge":"Star Forge",
-    "gtceu.star_forge":"Star Forge"
+    "gtceu.star_forge":"Star Forge",
+	"material.inert_nether_essence":"Inert Nether Star Essence"
 }

--- a/kubejs/server_scripts/mods/gtceu/gtceu.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceu.js
@@ -1,0 +1,22 @@
+ServerEvents.recipes(event => {
+    event.recipes.gtceu.chemical_bath('kubejs:chem_bath/inert_star')
+        .itemInputs('minecraft:wither_skeleton_skull')
+        .inputFluids(Fluid.of('gtceu:polyethylene', 1000))
+        .itemOutputs('kubejs:inert_nether_star')
+        .duration(1000)
+        .EUt(IV)
+    
+    event.recipes.gtceu.mixer('kubejs:mixer/inert_fluid')
+        .itemInputs('kubejs:inert_nether_star')
+        .inputFluids(Fluid.of('gtceu:aqua_regia', 2000))
+        .outputFluids(Fluid.of('gtceu:inert_nether_essence', 2304))
+        .duration(600)
+        .EUt(IV)
+    
+    event.recipes.gtceu.autoclave('kubejs:autoclave/nether_star')
+        .itemInputs('gtceu:polybenzimidazole_dust')
+        .inputFluids(Fluid.of('gtceu:inert_nether_essence', 144))
+        .itemOutputs('minecraft:nether_star')
+        .duration(1200)
+        .EUt(EV)
+})

--- a/kubejs/server_scripts/mods/mekanism/mekanism.js
+++ b/kubejs/server_scripts/mods/mekanism/mekanism.js
@@ -35,6 +35,81 @@ ServerEvents.recipes(e => {
     D: 'mekanism:electrolytic_core'
   }).id('kubejs:mekanismgenerators/gas_burning_gen')
   
+  // inert nether star
+  e.custom({
+    "type": "mekanism:reaction",
+    "duration": 100,
+    "fluidInput": {
+      "amount": 10,
+      "tag": "minecraft:water"
+    },
+    "gasInput": {
+      "amount": 100,
+      "gas": "mekanism:ethene"
+    },
+    "itemInput": {
+      "amount": 1,
+      "ingredient": {
+        "item": "minecraft:wither_skeleton_skull"
+      }
+    },
+    "itemOutput": {
+      "amount": 1,
+      "item": "kubejs:inert_nether_star"
+    },
+    "gasOutput": {
+      "amount": 100,
+      "gas": "kubejs:neutron_gas"
+    }
+  }).id('kubejs:reaction/inert_star/water_ethene')
+
+  // inert nether star duping
+  e.custom({
+    "type": "mekanism:reaction",
+    "duration": 400,
+    "energyRequired": 200,
+    "fluidInput": {
+      "amount": 200,
+      "tag": "minecraft:water"
+    },
+    "gasInput": {
+      "amount": 100,
+      "gas": "kubejs:neutron_gas"
+    },
+    "gasOutput": {
+      "amount": 10,
+      "gas": "mekanism:hydrogen"
+    },
+    "itemInput": {
+      "ingredient": {
+        "item": "kubejs:inert_nether_star"
+      }
+    },
+    "itemOutput": {
+      "count": 16,
+      "item": "kubejs:inert_nether_star"
+    }
+  }).id('kubejs:reaction/inert_star/water_neutron')
+
+  // inert nether star activation
+  e.custom({
+    "type": "mekanism:nucleosynthesizing",
+    "itemInput": {
+      "amount": 1,
+      "ingredient": {
+        "item": "kubejs:inert_nether_star"
+      }
+    },
+    "gasInput": {
+      "amount": 10,
+      "gas": "mekanism:antimatter"
+    },
+    "output": {
+      "count": 1,
+      "item": "minecraft:nether_star"
+    },
+    "duration": 200
+  }).id('kubejs:nucleosynthesizing/nether_star')
   
   //substrate
   

--- a/kubejs/startup_scripts/custom_additions.js
+++ b/kubejs/startup_scripts/custom_additions.js
@@ -1,3 +1,7 @@
 StartupEvents.registry('block', event => {
-	event.create('magical_soil').displayName('§bMagical Soil').material('grass').hardness(0.6);
+	event.create('magical_soil').displayName('§bMagical Soil').grassSoundType().mapColor('grass').hardness(0.6);
+})
+
+StartupEvents.registry('item', event => {
+	event.create('inert_nether_star').displayName('Inert Nether Star').texture(`minecraft:item/nether_star`).tooltip('Needs activating...')//.parentModel('minecraft:nether_star')
 })

--- a/kubejs/startup_scripts/gtceu/material_modification.js
+++ b/kubejs/startup_scripts/gtceu/material_modification.js
@@ -5,4 +5,8 @@ const $FluidStorageKeys = Java.loadClass('com.gregtechceu.gtceu.api.fluids.store
 GTCEuStartupEvents.registry('gtceu:material', event => {
     GTMaterials.NetherStar.setProperty($PropertyKey.FLUID, new $FluidProperty())
     GTMaterials.NetherStar.getProperty($PropertyKey.FLUID).storage.enqueueRegistration($FluidStorageKeys.LIQUID, new GTFluidBuilder())
+
+    event.create('inert_nether_essence')
+        .fluid()
+        .color(0x500bbf)
 })

--- a/kubejs/startup_scripts/mekanismStartup.js
+++ b/kubejs/startup_scripts/mekanismStartup.js
@@ -7,14 +7,24 @@
 */
 
 global.mekStackAdditions = [
-  //{material:'crimson_iron', color:'#fc9aad', makeDust: false},
-  //{material:'azure_silver', color:'#e89ffc', makeDust: false}
+  {material:'allthemodium', color:'#fed95a', makeDust: false},
+  {material:'vibranium', color:'#26de88', makeDust: false},
+  {material:'unobtainium', color:'#d152e3', makeDust: false},
+  {material:'aluminum', color:'#b1b9ba', makeDust: false},
+  {material:'nickel', color:'#d4cf9b', makeDust: false},
+  {material:'platinum', color:'#72cbec', makeDust: false},
+  {material:'silver', color:'#748494', makeDust: false},
+  {material:'zinc', color:'#487048', makeDust: false},
+  {material:'crimson_iron', color:'#fc9aad', makeDust: false},
+  {material:'azure_silver', color:'#e89ffc', makeDust: false}
 ]
 
 // DO NOT EDIT BELOW THIS LINE
 
 const $Slurry = Java.loadClass('mekanism.api.chemical.slurry.Slurry')
 const $SlurryBuilder = Java.loadClass('mekanism.api.chemical.slurry.SlurryBuilder')
+const $Gas = Java.loadClass('mekanism.api.chemical.gas.Gas')
+const $GasBuilder = Java.loadClass('mekanism.api.chemical.gas.GasBuilder')
 
 StartupEvents.registry('item', event => {
   const mekItems = ['clump', 'crystal', 'dirty_dust', 'shard']
@@ -44,7 +54,11 @@ StartupEvents.registry('item', event => {
 
 StartupEvents.registry('mekanism:slurry', event => {
   global.mekStackAdditions.forEach(entry => {
-    event.createCustom(`clean_${entry.material}`, () => $Slurry($SlurryBuilder.clean().ore(`forge:ores/${entry.material}`).color(Color.of(entry.color).getRgbJS())))
-    event.createCustom(`dirty_${entry.material}`, () => $Slurry($SlurryBuilder.dirty().ore(`forge:ores/${entry.material}`).color(Color.of(entry.color).getRgbJS())))
+    event.createCustom(`clean_${entry.material}`, () => $Slurry($SlurryBuilder.clean().ore(`forge:ores/${entry.material}`).tint(Color.of(entry.color).getRgbJS())))
+    event.createCustom(`dirty_${entry.material}`, () => $Slurry($SlurryBuilder.dirty().ore(`forge:ores/${entry.material}`).tint(Color.of(entry.color).getRgbJS())))
   })
+})
+
+StartupEvents.registry('mekanism:gas', event => {
+  event.createCustom(`neutron_gas`, () => $Gas($GasBuilder.builder()))
 })


### PR DESCRIPTION
This also adds the ATO and ATM ores to Mek ore processing - does require an update to ATO to function fully (fix is in [this PR](https://github.com/AllTheMods/AllTheOres/pull/37))

Mek processing line:
wither skeleton skull + 10mB water + 100mB ethylene in the Pressurized Reaction Chamber = 1 Inert Nether Star + 100mB Neutron Gas
inert nether star + 100mB neutron gas + 200mB water = 16 inert nether stars + 10mB hydrogen
inert nether star + 10mB antimatter in the Nucleosynthesizer = Nether Star

GT processing line (IV+):
1 wither skel skull + 1000mB polyethylene in the Chemical Bath = inert nether star
inert nether star + 1000mB aqua regia in the Mixer = 2304mB Inert Nether Star Essence
144mB inert essence + polybenzimidazole pulp in the Autoclave = nether star