### PR TITLE
MA Alloy Seed Recipe Adjustments

### DIFF
--- a/kubejs/server_scripts/mods/cataclysm/cataclysm.js
+++ b/kubejs/server_scripts/mods/cataclysm/cataclysm.js
@@ -1,7 +1,7 @@
 ServerEvents.entityLootTables(event => {
     event.modifyEntity('cataclysm:deepling_brute', table => {
         table.addPool(pool => {
-            pool.addItem('minecraft:heart_of_the_sea').randomChanceWithLooting(0.005, 0.005).killedByPlayer()
+            pool.addItem('minecraft:heart_of_the_sea').randomChanceWithLooting(0.05, 0.05).killedByPlayer()
         })
     })
     event.modifyEntity('cataclysm:the_leviathan', table => {

--- a/kubejs/server_scripts/mods/mysticalagriculture/crafting.js
+++ b/kubejs/server_scripts/mods/mysticalagriculture/crafting.js
@@ -1,3 +1,30 @@
+let cropAdjust = [
+  {crop:"steel", tier:"imperium"},
+  {crop:"bronze", tier:"tertium"},
+  {crop:"brass", tier:"tertium", block:"alltheores:brass_block"},
+  {crop:"nitro_crystal", tier:"insanium"},
+  {crop:"spirited_crystal", tier:"supremium"},
+  {crop:"niotic_crystal", tier:"supremium"},
+  {crop:"blazing_crystal", tier:"imperium"},
+  {crop:"energized_steel", tier:"imperium"},
+  {crop:"certus_quartz", tier:"tertium", block:"ae2:quartz_block"},
+  {crop:"fluix", tier:"imperium", block:"ae2:fluix_block"},
+  {crop:"soularium", tier:"imperium"},
+  {crop:"conductive_alloy", tier:"tertium"},
+  {crop:"copper_alloy", tier:"tertium"},
+  {crop:"end_steel", tier:"supremium"},
+  {crop:"redstone_alloy", tier:"tertium"},
+  {crop:"vibrant_alloy", tier:"supremium"},
+  {crop:"dark_steel", tier:"imperium"},
+  {crop:"pulsating_alloy", tier:"imperium"},
+  {crop:"energetic_alloy", tier:"imperium"},
+  {crop:"refined_glowstone", tier:"imperium", block:"mekanism:block_refined_glowstone"},
+  {crop:"refined_obsidian", tier:"imperium", block:"mekanism:block_refined_obsidian"},
+  {crop:"constantan", tier:"imperium"},
+  {crop:"cyanite", tier:"supremium", block:"bigreactors:cyanite_block"},
+  {crop:"graphite", tier:"tertium", block:"bigreactors:graphite_block"},
+]
+
 ServerEvents.recipes(event => {
   // essence crafting for custom seeds
   function essenceCircle(result, essenceType) {
@@ -9,22 +36,56 @@ ServerEvents.recipes(event => {
   essenceCircle('6x silentgear:azure_silver_ingot', 'azure_silver')
   essenceCircle('6x silentgear:crimson_iron_ingot', 'crimson_iron')
 
-  //magical soil crafting
-  event.custom({
-    type: 'mysticalagriculture:infusion',
-    input: { item: 'mysticalagradditions:insanium_farmland' },
-    ingredients: [
-      { item: 'mysticalagradditions:dragon_scale' },
-      { item: 'mysticalagradditions:insanium_block' },
-      { item: 'mysticalagradditions:dragon_scale' },
-      { item: 'mysticalagradditions:insanium_block' },
-      { item: 'mysticalagradditions:dragon_scale' },
-      { item: 'mysticalagradditions:insanium_block' },
-      { item: 'mysticalagradditions:dragon_scale' },
-      { item: 'mysticalagradditions:insanium_block' }
-    ],
-    result: { item: 'kubejs:magical_soil' }
+  // infusion seed crafting
+  function seedCrafting(output, middle, item1, item2, item3, item4, item5, item6, item7, item8){
+    event.custom({
+      type: 'mysticalagriculture:infusion',
+      input: { item: middle },
+      ingredients: [
+        { item: item1 },
+        { item: item2 },
+        { item: item3 },
+        { item: item4 },
+        { item: item5 },
+        { item: item6 },
+        { item: item7 },
+        { item: item8 }
+      ],
+      result: { item: output }
+    }).id(`kubejs:${output.replace(':', '/')}/infusion`)
+  }
+
+  // make alloy seeds use blocks to craft
+  cropAdjust.forEach(entry => {
+    let ess = ''
+    let block = ''
+
+    if (entry.tier == 'insanium') {
+      ess = `mysticalagradditions:insanium_essence`
+    } else {
+      ess = `mysticalagriculture:${entry.tier}_essence`
+    }
+
+    if (Item.exists(`allthecompressed:${entry.crop}_block_1x`)){
+      // use the allthecompressed block if it exists
+      block = `allthecompressed:${entry.crop}_block_1x`
+    } else if (entry.block !== undefined){
+      // else use the provided block in cropAdjust
+      block = entry.block
+    } else {
+      // else neither exists, fallback to the first thing we can find via the storage_blocks tag
+      block = Ingredient.of(`#forge:storage_blocks/${entry.crop}`).getItemIds()[0]
+    }
+    event.remove({id:`mysticalagriculture:seed/infusion/${entry.crop}`})
+    seedCrafting(`mysticalagriculture:${entry.crop}_seeds`, 'mysticalagriculture:prosperity_seed_base', ess, block, ess, block, ess, block, ess, block)
   })
+
+  // magical soil crafting
+  let soilMid = 'mysticalagradditions:insanium_farmland'
+  let soil1 = 'mysticalagradditions:dragon_scale'
+  let soil2 = 'mysticalagradditions:insanium_block'
+  seedCrafting('kubejs:magical_soil', soilMid, soil1, soil2, soil1, soil2, soil1, soil2, soil1, soil2)
+
 /*
   //MA EXP droplets to fluid EXP
   event.custom({
@@ -41,6 +102,6 @@ ServerEvents.recipes(event => {
     energy: 400
   })
 */
-  //remove gaia crux
+  // remove gaia crux
   event.remove({ id: "mysticalagradditions:gaia_spirit_crux" })
 })

--- a/kubejs/server_scripts/mods/mysticalagriculture/cropRemove.js
+++ b/kubejs/server_scripts/mods/mysticalagriculture/cropRemove.js
@@ -4,22 +4,8 @@ let cropRemove = [
     'tungsten',
     'titanium',
     'invar',
-    'steel',
     'iridium',
-    //"bronze",
-    //"brass",
-    //"certus_quartz",
-    //"fluix",
-    "constantan",
-    "cyanite",
     "yellorium",
-    "graphite",
-    //"rubber",
-    //"grains_of_infinity",
-    //"soularium",
-    //"dark_steel",
-    //"pulsating_alloy",
-    //"energetic_alloy",
 ]
 
 ServerEvents.recipes(event => {


### PR DESCRIPTION
Adds the steel seed back
Adjusts recipes for most alloy seeds to use the 1x compressed blocks instead of ingots
Sets the Heart of the Sea drop from Deepling Brute to 5% base rather than 0.5%

Full list of affected seeds below:
```
  "steel",
  "bronze",
  "brass",
  "nitro_crystal",
  "spirited_crystal", 
  "niotic_crystal", 
  "blazing_crystal",
  "energized_steel",
  "certus_quartz",
  "fluix",
  "soularium",
  "conductive_alloy",
  "copper_alloy",
  "end_steel", 
  "redstone_alloy",
  "vibrant_alloy", 
  "dark_steel",
  "pulsating_alloy",
  "energetic_alloy",
  "refined_glowstone",
  "refined_obsidian",
  "constantan",
  "cyanite",
  "graphite"
```