### PR TITLE
Recipe Adjustments and Config Changes

### DIFF
--- a/config/inventoryprofilesnext/integrationHints/ae2.json
+++ b/config/inventoryprofilesnext/integrationHints/ae2.json
@@ -81,8 +81,14 @@
         "playerSideOnly": true,
         "ignore": true
     },
+	"de.mari_023.ae2wtlib.wet.WETMenu": {
+        "ignore": true
+    },
     "de.mari_023.ae2wtlib.wct.WATScreen": {
         "playerSideOnly": true,
+        "ignore": true
+    },
+    "de.mari_023.ae2wtlib.wat.WATMenu": {
         "ignore": true
     },
     "de.mari_023.ae2wtlib.wct.WCTMenu": {

--- a/kubejs/server_scripts/conflicts.js
+++ b/kubejs/server_scripts/conflicts.js
@@ -22,5 +22,12 @@ ServerEvents.recipes(event => {
   event.smelting('gtceu:uraninite_dust', 'gtceu:raw_uraninite').id('atm9:gtceu/smelting_smelt_raw_uraninite_ore_to_ingot')
   event.blasting('gtceu:uraninite_dust', 'gtceu:raw_uraninite').id('atm9:gtceu/blasting_smelt_raw_uraninite_ore_to_ingot')
   event.shapeless('gtceu:raw_uraninite_block', '9x gtceu:raw_uraninite').id('atm9:gtceu/shaped_compress_uraninite_to_ore_block')
+
+  // Reborn Storage conflicts
+  event.remove({ output: /rebornstorage:(small|medium|large|larger)_(item|fluid)_disk.*/ })
+
+  // Extra Storage conflicts
+  event.remove({ output: /extrastorage:(block|disk|storagepart)_.+/ })
+  event.remove({ output: /extrastorage:advanced_(importer|exporter)/ })
 })
 

--- a/kubejs/server_scripts/mods/gtceu/gtceu.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceu.js
@@ -30,16 +30,22 @@ ServerEvents.recipes(event => {
         .duration(25600)
         .EUt(ULV)
 
-    //ALCR
-        event.recipes.gtceu.assembly_line('advanced_large_chemical_reactor')
-            .itemInputs('gtceu:large_chemical_reactor', '3x #forge:circuits/iv', '15x gtceu:nitinol_plate', '4x gtceu:platinum_single_cable')
-            .itemOutputs('gtceu:advanced_large_chemical_reactor')
-            .inputFluids(
-                Fluid.of('gtceu:copper', 4608),
-                Fluid.of('gtceu:tin', 4608),
-                Fluid.of('gtceu:soldering_alloy', 2304),
-                Fluid.of('gtceu:lubricant', 8000)
-            )
-            .duration(500)
-            .EUt(IV)
+    // ALCR
+    event.recipes.gtceu.assembly_line('advanced_large_chemical_reactor')
+        .itemInputs('gtceu:large_chemical_reactor', '3x #forge:circuits/iv', '15x gtceu:nitinol_plate', '4x gtceu:platinum_single_cable')
+        .itemOutputs('gtceu:advanced_large_chemical_reactor')
+        .inputFluids(
+            Fluid.of('gtceu:copper', 4608),
+            Fluid.of('gtceu:tin', 4608),
+            Fluid.of('gtceu:soldering_alloy', 2304),
+            Fluid.of('gtceu:lubricant', 8000)
+        )
+        .duration(500)
+        .EUt(IV)
+    
+    event.recipes.gtceu.assembler('uhv_16a_energy_hatch')
+        .itemInputs('2x gtceu:uhv_energy_input_hatch_4a', '2x gtceu:uhpic_chip', 'kubejs:superthermal_transference_coil', '2x kubejs:cable_of_hyperconductivity')
+        .itemOutputs('gtceu:uhv_energy_input_hatch_16a')
+        .duration(200)
+        .EUt(UHV)
 })

--- a/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
@@ -6,12 +6,12 @@ ServerEvents.recipes(event => {
             '8x gtceu:uv_machine_hull',
             '8x gtceu:advanced_power_thruster',
             '2x gtceu:hsse_drill_head',
-            '4x gtceu:uv_field_generator',
-            '4x #forge:circuits/uhv',
+            '2x gtceu:uv_field_generator',
+            '2x #forge:circuits/uhv',
             '32x gtceu:ruthenium_trinium_americium_neutronate_single_wire'
         ])
         .inputFluids([
-            Fluid.of('gtceu:naquadria', 2592),
+            Fluid.of('gtceu:naquadria', 1296),
             Fluid.of('gtceu:soldering_alloy', 1152)
         ])
         .itemOutputs('1x kubejs:micro_universe_drill_ship')

--- a/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
@@ -73,28 +73,32 @@ ServerEvents.recipes(event => {
 
     // Resource Generation
     event.recipes.gtceu.micro_universe_collector('otherworldy_ore')
-        .itemInputs(['16x kubejs:micro_universe_catalyst', '1x kubejs:micro_universe_drill_ship', '16x #forge:ingots/uranium_235'])
+        .notConsumable('16x kubejs:micro_universe_catalyst')
+        .itemInputs(['1x kubejs:micro_universe_drill_ship', '16x #forge:ingots/uranium_235'])
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:nether_star', 144 * 16)])
         .itemOutputs(['288x gtceu:neutronium_nugget', '126x allthemodium:allthemodium_nugget', '126x allthemodium:unobtainium_nugget', '126x gtceu:naquadria_nugget'])
         .outputFluids([Fluid.of('gtceu:samarium', 12960), Fluid.of('gtceu:darmstadtium', 4608)])
         .duration(12000).EUt(UHV * 36)
 
     event.recipes.gtceu.micro_universe_collector('end_ore')
-        .itemInputs(['16x kubejs:micro_universe_catalyst', '1024x minecraft:end_stone', '1x kubejs:micro_universe_drill_ship'])
+        .notConsumable('16x kubejs:micro_universe_catalyst')
+        .itemInputs(['1x kubejs:micro_universe_drill_ship', '1024x minecraft:end_stone'])
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:ender_air', 1000000), Fluid.of('gtceu:nether_star', 144 * 64)])
         .itemOutputs(['512x gtceu:endstone_naquadah_ore', '512x gtceu:endstone_trinium_ore', '512x gtceu:endstone_plutonium_ore', '1024x gtceu:endstone_tungstate_ore'])
         .outputFluids([Fluid.of('gtceu:liquid_ender_air', 64000), Fluid.of('gtceu:tritium', 32000)])
         .duration(18000).EUt(UHV * 36)
 
     event.recipes.gtceu.micro_universe_collector('nether_ore')
-        .itemInputs(['16x kubejs:micro_universe_catalyst', '1024x minecraft:netherrack', '1x kubejs:micro_universe_drill_ship'])
+        .notConsumable('16x kubejs:micro_universe_catalyst')
+        .itemInputs(['1x kubejs:micro_universe_drill_ship', '1024x minecraft:netherrack'])
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:nether_air', 1000000), Fluid.of('gtceu:nether_star', 144 * 16)])
         .itemOutputs(['1024x gtceu:netherrack_sulfur_ore', '1024x gtceu:netherrack_tetrahedrite_ore', '512x gtceu:netherrack_sphalerite_ore', '512x gtceu:netherrack_gold_ore'])
         .outputFluids([Fluid.of('gtceu:liquid_nether_air', 64000), Fluid.of('minecraft:lava', 100000), Fluid.of('gtceu:inert_nether_essence', 16000)])
         .duration(12000).EUt(UHV * 12)
 
     event.recipes.gtceu.micro_universe_collector('overworld_ore')
-        .itemInputs(['16x kubejs:micro_universe_catalyst', '1024x minecraft:stone', '1x kubejs:micro_universe_drill_ship'])
+        .notConsumable('16x kubejs:micro_universe_catalyst')
+        .itemInputs(['1x kubejs:micro_universe_drill_ship', '1024x minecraft:stone'])
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:air', 1000000), Fluid.of('gtceu:nether_star', 144 * 16)])
         .itemOutputs(['1280x gtceu:copper_ore', '1024x gtceu:tin_ore', '512x gtceu:iron_ore', '512x gtceu:diamond_ore', '16x allthemodium:allthemodium_ore'])
         .outputFluids([Fluid.of('gtceu:liquid_air', 64000), Fluid.of('gtceu:oil', 100000)])
@@ -103,12 +107,14 @@ ServerEvents.recipes(event => {
 
     // Energy Generation
     event.recipes.gtceu.micro_universe_reactor('uhv_power')
-        .itemInputs(['16x kubejs:micro_universe_catalyst', '1x kubejs:micro_universe_drill_ship', '256x gtceu:naquadria_ingot', '128x gtceu:neutronium_ingot', '1x #forge:batteries/uv'])
+        .notConsumable('16x kubejs:micro_universe_catalyst')
+        .itemInputs(['1x kubejs:micro_universe_drill_ship', '256x gtceu:naquadria_ingot', '128x gtceu:neutronium_ingot', '1x #forge:batteries/uv'])
         .inputFluids(Fluid.of('gtceu:nether_star', 144 * 16))
         .duration(18000).EUt(-(GTValues.V[GTValues.UEV] * 16))
 
     event.recipes.gtceu.micro_universe_reactor('uev_power')
-        .itemInputs(['16x kubejs:micro_universe_catalyst', '1x kubejs:micro_universe_drill_ship', '256x gtceu:tritanium_ingot', '128x gtceu:neutronium_ingot', '1x #forge:batteries/uhv'])
+        .notConsumable('16x kubejs:micro_universe_catalyst')
+        .itemInputs(['1x kubejs:micro_universe_drill_ship', '256x gtceu:tritanium_ingot', '128x gtceu:neutronium_ingot', '1x #forge:batteries/uhv'])
         .inputFluids(Fluid.of('gtceu:nether_star', 144 * 16))
         .duration(18000).EUt(-(GTValues.V[GTValues.UIV] * 16))
 })


### PR DESCRIPTION
- Removed the RebornStorage and ExtraStorage recipes that are hidden in JEI
- Added Inventory Profiles Next config to ignore middle mouse clicks inside different parts of the AE2 wireless terminal
- Made the Micro Universe Catalyst not consumed in the Micro Universe Orb recipes
- Added a recipe for the UHV 16A Energy Hatch
- Made the Micro Universe Drill Ship a bit cheaper