### PR TITLE
Swap Yellorium for Uranium in ER2 Fluidizer

### DIFF
--- a/kubejs/data/bigreactors/recipes/fluidizer/solid/yellorium9.json
+++ b/kubejs/data/bigreactors/recipes/fluidizer/solid/yellorium9.json
@@ -1,0 +1,13 @@
+{
+    "type": "bigreactors:fluidizersolid",
+    "ingredient": {
+      "count": 1,
+      "ingredient": {
+        "item": "alltheores:uranium_block"
+      }
+    },
+    "result": {
+      "count": 9000,
+      "fluid": "bigreactors:yellorium"
+    }
+  }

--- a/kubejs/data/bigreactors/recipes/fluidizer/solidmixing/verderium9_1.json
+++ b/kubejs/data/bigreactors/recipes/fluidizer/solidmixing/verderium9_1.json
@@ -1,0 +1,19 @@
+{
+    "type": "bigreactors:fluidizersolidmixing",
+    "ingredient1": {
+      "count": 2,
+      "ingredient": {
+        "item": "alltheores:uranium_block"
+      }
+    },
+    "ingredient2": {
+      "count": 1,
+      "ingredient": {
+        "item": "bigreactors:blutonium_block"
+      }
+    },
+    "result": {
+      "count": 18000,
+      "fluid": "bigreactors:verderium"
+    }
+  }

--- a/kubejs/data/bigreactors/recipes/fluidizer/solidmixing/verderium9_2.json
+++ b/kubejs/data/bigreactors/recipes/fluidizer/solidmixing/verderium9_2.json
@@ -1,0 +1,19 @@
+{
+    "type": "bigreactors:fluidizersolidmixing",
+    "ingredient1": {
+      "count": 1,
+      "ingredient": {
+        "item": "bigreactors:blutonium_block"
+      }
+    },
+    "ingredient2": {
+      "count": 2,
+      "ingredient": {
+        "item": "alltheores:uranium_block"
+      }
+    },
+    "result": {
+      "count": 18000,
+      "fluid": "bigreactors:verderium"
+    }
+  }

--- a/kubejs/data/bigreactors/recipes/fluidizer/solidmixing/verderium_1.json
+++ b/kubejs/data/bigreactors/recipes/fluidizer/solidmixing/verderium_1.json
@@ -1,0 +1,19 @@
+{
+    "type": "bigreactors:fluidizersolidmixing",
+    "ingredient1": {
+      "count": 2,
+      "ingredient": {
+        "item": "alltheores:uranium_ingot"
+      }
+    },
+    "ingredient2": {
+      "count": 1,
+      "ingredient": {
+        "item": "bigreactors:blutonium_ingot"
+      }
+    },
+    "result": {
+      "count": 2000,
+      "fluid": "bigreactors:verderium"
+    }
+  }

--- a/kubejs/data/bigreactors/recipes/fluidizer/solidmixing/verderium_2.json
+++ b/kubejs/data/bigreactors/recipes/fluidizer/solidmixing/verderium_2.json
@@ -1,0 +1,19 @@
+{
+    "type": "bigreactors:fluidizersolidmixing",
+    "ingredient1": {
+      "count": 1,
+      "ingredient": {
+        "item": "bigreactors:blutonium_ingot"
+      }
+    },
+    "ingredient2": {
+      "count": 2,
+      "ingredient": {
+        "item": "alltheores:uranium_ingot"
+      }
+    },
+    "result": {
+      "count": 2000,
+      "fluid": "bigreactors:verderium"
+    }
+  }

--- a/kubejs/server_scripts/conflicts.js
+++ b/kubejs/server_scripts/conflicts.js
@@ -1,4 +1,8 @@
 ServerEvents.recipes(event => {
+
+  // Yellorium
+  event.remove({ id: 'bigreactors:crafting/yellorium_component_to_storage' })
+  event.remove({ id: 'bigreactors:crafting/yellorium_ingot_to_nugget' })
   
   // Fire for Standing Torch
   event.remove({ id: 'additional_lights:fire_for_standing_torch_s' })


### PR DESCRIPTION
Also removes recipes to create Yellorium nuggets and blocks since their uses should all be replaced by uranium