### PR TITLE
Disable F&A Soul entities and limit vengeance spirits.

### DIFF
--- a/config/evilcraft-common.toml
+++ b/config/evilcraft-common.toml
@@ -313,13 +313,13 @@
 		#The 1/X chance that an actual spirit will spawn when doing actions like mining with the Vengeance Pickaxe.
 		nonDegradedSpawnChance = 5
 		#The area in which the spawn limit will be checked on each spawn attempt.
-		spawnLimitArea = 32
+		spawnLimitArea = 64
 		#The blacklisted entity spirits, by entity name. Regular expressions are allowed.
 		entityBlacklist = ["evilcraft:vengeance_spirit", "evilcraft:controlled_zombie", "evilcraft:werewolf", "minecraft:ender_dragon", "farmingforblockheads:merchant"]
 		#Whether vengeance spirits should always be visible in creative mode.
 		alwaysVisibleInCreative = false
 		#The maximum amount of vengeance spirits naturally spawnable in the spawnLimitArea.
-		spawnLimit = 5
+		spawnLimit = 2
 
 [entity]
 

--- a/kubejs/data/forbidden_arcanus/forge/biome_modifier/add_lost_soul_nether.json
+++ b/kubejs/data/forbidden_arcanus/forge/biome_modifier/add_lost_soul_nether.json
@@ -1,0 +1,13 @@
+{
+  "type": "valhelsia_core:add_nether_spawns",
+  "biomes": "#forge:none",
+  "category": "monster",
+  "charge": 1.1,
+  "energyBudget": 1.0,
+  "spawners": {
+    "type": "forbidden_arcanus:lost_soul",
+    "maxCount": 4,
+    "minCount": 1,
+    "weight": 60
+  }
+}

--- a/kubejs/data/forbidden_arcanus/forge/biome_modifier/add_lost_soul_overworld.json
+++ b/kubejs/data/forbidden_arcanus/forge/biome_modifier/add_lost_soul_overworld.json
@@ -1,0 +1,10 @@
+{
+  "type": "forge:add_spawns",
+  "biomes": "#forge:none",
+  "spawners": {
+    "type": "forbidden_arcanus:lost_soul",
+    "maxCount": 3,
+    "minCount": 1,
+    "weight": 35
+  }
+}

--- a/kubejs/data/forbidden_arcanus/tags/entity_types/spawns_corrupt_lost_soul_chance.json
+++ b/kubejs/data/forbidden_arcanus/tags/entity_types/spawns_corrupt_lost_soul_chance.json
@@ -1,0 +1,3 @@
+{
+  "values": replace:true
+}

--- a/kubejs/data/forbidden_arcanus/tags/entity_types/spawns_lost_soul_chance.json
+++ b/kubejs/data/forbidden_arcanus/tags/entity_types/spawns_lost_soul_chance.json
@@ -1,0 +1,3 @@
+{
+  "values": replace:true
+}


### PR DESCRIPTION
This is a datapack to fully disable F&A souls from spawning and a config change to  limit the vengeance spirits to 2 spirits in a 64 block radius.