### PR TITLE
enable observable profiling for non-opped players

### DIFF
--- a/config/observable.json
+++ b/config/observable.json
@@ -1,0 +1,1 @@
+{"allPlayersAllowed":true}


### PR DESCRIPTION
Note for server owners: this only allows them to run the profiler for whatever they're around and access the website to see what's bringing it down. They're unable to use the commands still to teleport around.