### PR TITLE
Gregtech Battery and Circuit Tag Fix

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/gtceu.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceu.js
@@ -32,7 +32,7 @@ ServerEvents.recipes(event => {
 
     // ALCR
     event.recipes.gtceu.assembly_line('advanced_large_chemical_reactor')
-        .itemInputs('gtceu:large_chemical_reactor', '3x #forge:circuits/iv', '15x gtceu:nitinol_plate', '4x gtceu:platinum_single_cable')
+        .itemInputs('gtceu:large_chemical_reactor', '3x #gtceu:circuits/iv', '15x gtceu:nitinol_plate', '4x gtceu:platinum_single_cable')
         .itemOutputs('gtceu:advanced_large_chemical_reactor')
         .inputFluids(
             Fluid.of('gtceu:copper', 4608),

--- a/kubejs/server_scripts/mods/gtceu/mega_fusion_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/mega_fusion_recipes.js
@@ -5,7 +5,7 @@ ServerEvents.recipes(event => {
         .itemInputs([
             '2x gtceu:uv_fusion_reactor',
             '4x gtceu:fusion_coil',
-            '4x #forge:circuits/uhv',
+            '4x #gtceu:circuits/uhv',
             '2x gtceu:neutronium_plate',
             '4x gtceu:uv_field_generator',
             '8x gtceu:gravi_star',

--- a/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
@@ -7,7 +7,7 @@ ServerEvents.recipes(event => {
             '8x gtceu:advanced_power_thruster',
             '2x gtceu:hsse_drill_head',
             '2x gtceu:uv_field_generator',
-            '2x #forge:circuits/uhv',
+            '2x #gtceu:circuits/uhv',
             '32x gtceu:ruthenium_trinium_americium_neutronate_single_wire'
         ])
         .inputFluids([
@@ -57,7 +57,7 @@ ServerEvents.recipes(event => {
             '1x gtceu:uhv_machine_hull',
             '4x kubejs:micro_universe_catalyst',
             '4x gtceu:atomic_casing',
-            '6x #forge:circuits/uhv',
+            '6x #gtceu:circuits/uhv',
             '8x gtceu:gravi_star',
             '64x gtceu:uhpic_chip',
             '64x gtceu:uhpic_chip'
@@ -108,13 +108,13 @@ ServerEvents.recipes(event => {
     // Energy Generation
     event.recipes.gtceu.micro_universe_reactor('uhv_power')
         .notConsumable('16x kubejs:micro_universe_catalyst')
-        .itemInputs(['1x kubejs:micro_universe_drill_ship', '256x gtceu:naquadria_ingot', '128x gtceu:neutronium_ingot', '1x #forge:batteries/uv'])
+        .itemInputs(['1x kubejs:micro_universe_drill_ship', '256x gtceu:naquadria_ingot', '128x gtceu:neutronium_ingot', '1x #gtceu:batteries/uv'])
         .inputFluids(Fluid.of('gtceu:nether_star', 144 * 16))
         .duration(18000).EUt(-(GTValues.V[GTValues.UEV] * 16))
 
     event.recipes.gtceu.micro_universe_reactor('uev_power')
         .notConsumable('16x kubejs:micro_universe_catalyst')
-        .itemInputs(['1x kubejs:micro_universe_drill_ship', '256x gtceu:tritanium_ingot', '128x gtceu:neutronium_ingot', '1x #forge:batteries/uhv'])
+        .itemInputs(['1x kubejs:micro_universe_drill_ship', '256x gtceu:tritanium_ingot', '128x gtceu:neutronium_ingot', '1x #gtceu:batteries/uhv'])
         .inputFluids(Fluid.of('gtceu:nether_star', 144 * 16))
         .duration(18000).EUt(-(GTValues.V[GTValues.UIV] * 16))
 })

--- a/kubejs/server_scripts/mods/gtceu/starforge_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/starforge_recipes.js
@@ -120,7 +120,7 @@ ServerEvents.recipes(event => {
 		.itemInputs(
 			[
 				'gtceu:uhv_machine_hull',
-                '4x #forge:circuits/uhv',
+                '4x #gtceu:circuits/uhv',
 				'4x gtceu:gravi_star',
 				'4x gtceu:uv_field_generator',
 				'64x gtceu:uhpic_chip',


### PR DESCRIPTION
Changes the tag format of GT batteries and circuits from "forge:" to "gtceu:" to match updated gtceu modern