### PR TITLE
Final GT Quests. (UHV and GregStar)

### DIFF
--- a/config/ftbquests/quests/chapters/circuits.snbt
+++ b/config/ftbquests/quests/chapters/circuits.snbt
@@ -4,7 +4,7 @@
 	filename: "circuits"
 	group: "1DA67E79B40AB130"
 	id: "560EF4C38DEACA03"
-	order_index: 10
+	order_index: 12
 	quest_links: [ ]
 	quests: [
 		{

--- a/config/ftbquests/quests/chapters/gregstar.snbt
+++ b/config/ftbquests/quests/chapters/gregstar.snbt
@@ -2,7 +2,7 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "gregstar"
-	group: ""
+	group: "1DA67E79B40AB130"
 	icon: "allthetweaks:greg_star"
 	id: "3202C575456F57D2"
 	images: [
@@ -32,7 +32,7 @@
 			y: 0.0d
 		}
 	]
-	order_index: 42
+	order_index: 11
 	quest_links: [ ]
 	quests: [
 		{

--- a/config/ftbquests/quests/chapters/gregstar.snbt
+++ b/config/ftbquests/quests/chapters/gregstar.snbt
@@ -1,0 +1,1629 @@
+{
+	default_hide_dependency_lines: false
+	default_quest_shape: ""
+	filename: "gregstar"
+	group: ""
+	icon: "allthetweaks:greg_star"
+	id: "3202C575456F57D2"
+	images: [
+		{
+			click: ""
+			corner: false
+			dev: false
+			height: 12.0d
+			hover: [ ]
+			image: "gtceu:textures/gui/icon/gregtech_logo.png"
+			order: 1
+			rotation: 0.0d
+			width: 12.0d
+			x: 0.0d
+			y: 0.0d
+		}
+		{
+			click: ""
+			corner: false
+			dev: false
+			height: 16.0d
+			hover: [ ]
+			image: "gtceu:block/casings/gcym/atomic_casing"
+			rotation: 0.0d
+			width: 16.0d
+			x: 0.0d
+			y: 0.0d
+		}
+	]
+	order_index: 42
+	quest_links: [ ]
+	quests: [
+		{
+			dependencies: [
+				"55ACA94C7837FF5E"
+				"502FF1A93E06073C"
+				"7C8DE42ADB6E1AA4"
+				"43D3E61FA314E3C3"
+				"3BF90C250AC1ADF3"
+				"1BB1E43FFE3FD451"
+				"5520FCC832251168"
+				"7AD22973EDC05877"
+				"64FD043694770843"
+				"078F7CEE4CAC39D6"
+				"5C6F8FE4BA28807E"
+				"768951FBE8A5C934"
+			]
+			description: [
+				"At Long Last we have reached our Destination. You have crafted the Coveted &l&1GregStar!&r&r"
+				""
+				"The culmination of achievements through each tier of GregTech, mastering each processing line and obtaining materials, machines, and items with increased difficulty each Tier."
+				""
+				"But you have done it. You made it. The GregStar!"
+				""
+				"There is still more to do, so get your head back in the game, and get ready for the BIGGEST challenge yet! Literally."
+			]
+			id: "12B041E34F58FDD2"
+			rewards: [
+				{
+					id: "079EC0C14DCA12A3"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "17A2EC9123FFC20F"
+					item: {
+						Count: 1b
+						id: "gtceu:doge_coin"
+						tag: {
+							display: {
+								Name: "{\"text\":\"GregStar Champion\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+				{
+					exclude_from_claim_all: true
+					id: "0D282CB3BE5846A4"
+					table_id: 7175652334583451871L
+					type: "loot"
+				}
+				{
+					exclude_from_claim_all: true
+					id: "5D5E8465D601BD08"
+					table_id: 1193402146821170967L
+					type: "loot"
+				}
+			]
+			shape: "gear"
+			size: 4.0d
+			subtitle: "At Long Last"
+			tasks: [{
+				id: "4F4B24FF54D99BBC"
+				item: "allthetweaks:greg_star"
+				type: "item"
+			}]
+			x: 0.0d
+			y: 0.0d
+		}
+		{
+			dependencies: [
+				"539D5084283C6219"
+				"008DBEF8893F1B63"
+				"583F0F3C00D211BE"
+				"61D9E67FFA14A8F8"
+				"5FE8521046CA1C8D"
+				"59A7880359BB5698"
+				"0373198D54FA6B93"
+			]
+			description: [
+				"Before we can piece together the GregStar with all the components from this page, you need to craft the base the star will be build upon."
+				""
+				"The Robust Star Housing is strong enough to withstand the forces exerted in the star forge, and support the components that make up the GregStar"
+			]
+			id: "502FF1A93E06073C"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "2C57468075D5E46A"
+					table_id: 1193402146821170967L
+					type: "loot"
+				}
+				{
+					id: "76557FEF986B1D5B"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "7EA634913596A091"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_hammer"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								Damage: 0
+								HarvestLevel: 6
+								MaxDamage: 65534
+								ToolSpeed: 184.0f
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Robustness\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Precursor"
+			tasks: [{
+				id: "1D2982FDB07A9275"
+				item: "kubejs:star_housing"
+				type: "item"
+			}]
+			x: 0.0d
+			y: -7.5d
+		}
+		{
+			dependencies: ["217FA79B7D4C56CD"]
+			description: [
+				"At this point, you have learned so much through the Tiers, you should be rewarded with something to display your knowledge!"
+				""
+				"In this case, this certificate shall suffice. You are officially, Not a Noob anymore!"
+			]
+			id: "55ACA94C7837FF5E"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "32CDDD669E0CAD4D"
+					table_id: 8781463007120195614L
+					type: "loot"
+				}
+				{
+					id: "6B9406278F8E6336"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "7833ED29A4D06F8D"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_file"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								AttackDamage: 0.0f
+								AttackSpeed: -1.9000001f
+								Damage: 0
+								MaxDamage: 65534
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Noobs\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Certifications!"
+			tasks: [{
+				id: "0EF09E7910979B85"
+				item: "gtceu:nan_certificate"
+				type: "item"
+			}]
+			x: -4.5d
+			y: -7.5d
+		}
+		{
+			dependencies: [
+				"452B3207B6C3A5D7"
+				"754229E1F1D2DA8A"
+				"44BE268EC7D2689D"
+				"0737D64B0CCAE334"
+			]
+			description: [
+				"The Fusion Reactors require some strong materials to contain the immense heat and reactions happening inside of them."
+				""
+				"Thats why they make an incredibly suitable material for us to use in crafting the GregStar to ensure Strength and Durability of the star!"
+			]
+			id: "5520FCC832251168"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "6751457CCB6829E6"
+					table_id: 1193402146821170967L
+					type: "loot"
+				}
+				{
+					id: "496A320899F181F7"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "54AF08C2D3E98EA6"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_wrench"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								Damage: 0
+								HarvestLevel: 6
+								MaxDamage: 65534
+								ToolSpeed: 184.0f
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Reaction\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Star Plating"
+			tasks: [{
+				id: "67EB36B2DFE42688"
+				item: "kubejs:absolute_reaction_plating"
+				type: "item"
+			}]
+			x: -7.5d
+			y: -6.0d
+		}
+		{
+			dependencies: [
+				"05D6CE1B501F59B5"
+				"38C0D3A240E43A23"
+				"59908911C4FFF223"
+				"476B99789CA7BD96"
+			]
+			description: ["Add in UV power delivery blocks, and an ATM star, and BAM! You now have the Star Compression Module."]
+			id: "7AD22973EDC05877"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "7E1D81CEFB009A48"
+					table_id: 1193402146821170967L
+					type: "loot"
+				}
+				{
+					id: "539FEF2BE77497D6"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "1D803FBEE9C53C00"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_saw"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								HarvestIce: 1b
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								Damage: 0
+								MaxDamage: 65534
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Star Compression\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Star Compression"
+			tasks: [{
+				id: "6A97BAA42843B8FB"
+				item: "kubejs:star_compression_module"
+				type: "item"
+			}]
+			x: -7.5d
+			y: -2.25d
+		}
+		{
+			dependencies: [
+				"61428FAD831DC213"
+				"762BD49C9589EB3F"
+				"176C06C7593C264E"
+			]
+			description: ["Exchanging heat in any case is usually very expensive in Energy cost. In this case, some Tritainium coils, Ultimate Voltage Coils, and Large Naquadria Batteries will do the trick."]
+			id: "43D3E61FA314E3C3"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "3E72880B3FBB29F3"
+					table_id: 1193402146821170967L
+					type: "loot"
+				}
+				{
+					id: "6642C0631A74B7DA"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "1FF8A481DA1BD909"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_screwdriver"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								Damage: 0
+								MaxDamage: 65534
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Superthermal Coils\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Thermal Exchange"
+			tasks: [{
+				id: "65EFA533C13D4AC6"
+				item: "kubejs:superthermal_transference_coil"
+				type: "item"
+			}]
+			x: -7.5d
+			y: 3.0d
+		}
+		{
+			description: [
+				"By this point, we are no stranger to Antimatter pellets."
+				""
+				"We just need more of them for the GregStar. A LOT more of them."
+			]
+			icon: "mekanism:pellet_antimatter"
+			id: "64FD043694770843"
+			rewards: [
+				{
+					id: "50D97BFC0249C02E"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "0B4FBB31F08719C1"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_knife"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								AttackDamage: 100.0f
+								AttackSpeed: 3.5f
+								Damage: 0
+								MaxDamage: 65534
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Antimatter\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "More Antimatter?"
+			tasks: [
+				{
+					count: 32L
+					id: "2338E8F51AA010F0"
+					item: "mekanism:pellet_antimatter"
+					type: "item"
+				}
+				{
+					id: "1B29FC754B2B26AF"
+					item: "gtceu:wetware_processor_mainframe"
+					type: "item"
+				}
+			]
+			x: 0.0d
+			y: 7.5d
+		}
+		{
+			description: [
+				"Lets add in some Industrial Foregoing Black Hole Controllers, just for good measure."
+				""
+				"This way, we know that the resulting Star can be controlled, and its immense power wont run rampantly out of control."
+			]
+			icon: "industrialforegoing:black_hole_controller"
+			id: "3BF90C250AC1ADF3"
+			rewards: [
+				{
+					id: "3B3B1EC6201843B3"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "1D67E56AD648D757"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_crowbar"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								Damage: 0
+								HarvestLevel: 6
+								MaxDamage: 65534
+								ToolSpeed: 184.0f
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Blackhole Controllers\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Black Hole Controller"
+			tasks: [
+				{
+					count: 8L
+					id: "2F81C3902406C1AE"
+					item: "industrialforegoing:black_hole_controller"
+					type: "item"
+				}
+				{
+					id: "33C07AA1C90F8D6C"
+					item: "gtceu:wetware_processor_mainframe"
+					type: "item"
+				}
+			]
+			x: 6.0d
+			y: 7.5d
+		}
+		{
+			description: [
+				"With the strength of Unobtainium, it only makes sense that the GregStar would include some in the build."
+				""
+				"There are no concerns of Structural Integrity at this point."
+			]
+			icon: "ironfurnaces:unobtainium_furnace"
+			id: "078F7CEE4CAC39D6"
+			rewards: [
+				{
+					id: "5DFC2B1015CCE3E4"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "6B501879B039115A"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_scythe"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								AoEColumn: 2
+								AoELayer: 2
+								AoERow: 2
+								MaxAoEColumn: 2
+								MaxAoELayer: 2
+								MaxAoERow: 2
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								AttackDamage: 105.0f
+								AttackSpeed: -2.5f
+								Damage: 0
+								HarvestLevel: 6
+								MaxDamage: 196604
+								ToolSpeed: 184.0f
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Unobtainum Furnaces\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Unobtainium"
+			tasks: [
+				{
+					count: 16L
+					id: "7DB9B3F5E5D7E301"
+					item: "ironfurnaces:unobtainium_furnace"
+					type: "item"
+				}
+				{
+					id: "3AB9F40D6DB23750"
+					item: "gtceu:wetware_processor_mainframe"
+					type: "item"
+				}
+			]
+			x: 7.5d
+			y: 3.0d
+		}
+		{
+			description: ["Some Advanced Computers."]
+			icon: "computercraft:computer_advanced"
+			id: "5C6F8FE4BA28807E"
+			rewards: [
+				{
+					id: "5AC196B0241610D3"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "1DBF22541766EC89"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_hoe"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								Damage: 0
+								MaxDamage: 65534
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Computers\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Advanced Computers"
+			tasks: [
+				{
+					count: 32L
+					id: "4FA25206854F9ADC"
+					item: "computercraft:computer_advanced"
+					type: "item"
+				}
+				{
+					id: "76495B10C6046626"
+					item: "gtceu:wetware_processor_mainframe"
+					type: "item"
+				}
+			]
+			x: 7.5d
+			y: -2.25d
+		}
+		{
+			dependencies: [
+				"5AAD0E516762BA53"
+				"3673893C88EB5EDE"
+				"70B518EC050678AE"
+			]
+			description: ["Craft a End Steel Exchanger to be used in the production of the GregStar."]
+			icon: {
+				Count: 1b
+				id: "exchangers:end_steel_exchanger"
+				tag: {
+					Energy: 50000000
+					blockstate: {
+						Name: "minecraft:air"
+					}
+					directionalPlacement: 0b
+					forceDropItems: 0b
+					fuzzyPlacement: 0b
+					fuzzyPlacementChance: 100
+					mode: 0
+					range: 0
+					voidItems: 0b
+				}
+			}
+			id: "7C8DE42ADB6E1AA4"
+			rewards: [
+				{
+					id: "5F2BB41E65055811"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "149896B514C74991"
+					item: {
+						Count: 1b
+						id: "gtceu:polybenzimidazole_mallet"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: { }
+							GT.Tool: {
+								Damage: 0
+								MaxDamage: 127
+							}
+							HideFlags: 2
+							display: {
+								Name: "{\"text\":\"Champion of Exchangers\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Exchangers"
+			tasks: [
+				{
+					id: "3800D50E1B753AF5"
+					item: {
+						Count: 1b
+						id: "exchangers:end_steel_exchanger"
+						tag: {
+							blockstate: {
+								Name: "minecraft:air"
+							}
+							directionalPlacement: 0b
+							forceDropItems: 0b
+							fuzzyPlacement: 0b
+							fuzzyPlacementChance: 100
+							mode: 0
+							range: 0
+							voidItems: 0b
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "43F97CA2879574DF"
+					item: "gtceu:wetware_processor_mainframe"
+					type: "item"
+				}
+			]
+			x: 7.5d
+			y: -6.0d
+		}
+		{
+			description: [
+				"You are going to need quite a bit of this as a catalyst in the Star Forge in order to craft the GregStar."
+				""
+				"Make sure you have 10 buckets available."
+			]
+			icon: "gtceu:europium_bucket"
+			id: "1BB1E43FFE3FD451"
+			rewards: [
+				{
+					id: "2300694655109F1B"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "70306D7DB3498C01"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_sword"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								AttackDamage: 103.0f
+								AttackSpeed: -1.9000001f
+								Damage: 0
+								MaxDamage: 65534
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Europe\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Europium"
+			tasks: [
+				{
+					id: "048CC07BDFB7717A"
+					item: "gtceu:europium_bucket"
+					type: "item"
+				}
+				{
+					id: "7466B3E2616A7E33"
+					item: "gtceu:wetware_processor_mainframe"
+					type: "item"
+				}
+			]
+			x: 4.5d
+			y: -7.5d
+		}
+		{
+			description: [
+				"The Base Star, the Patrick Star, that was used to make a Star, and now is the base for another Star that will be made into a Star. "
+				""
+				"Got it? K. Lets move on."
+			]
+			id: "0373198D54FA6B93"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "5742821F5E80962E"
+				table_id: 7025454341029952768L
+				type: "loot"
+			}]
+			subtitle: "The Star that started it all"
+			tasks: [{
+				id: "6F4F04DFB8480B74"
+				item: "allthetweaks:patrick_star"
+				type: "item"
+			}]
+			x: 0.0d
+			y: -9.5d
+		}
+		{
+			description: ["Double Tungstensteel plating will make for a very durable Star. Maybe this is where it gets its Robustness from."]
+			id: "5FE8521046CA1C8D"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "62B2B2E89398549A"
+				table_id: 6202000790833671070L
+				type: "loot"
+			}]
+			subtitle: "Double it Up"
+			tasks: [{
+				id: "04345494A9907466"
+				item: "gtceu:double_tungsten_steel_plate"
+				type: "item"
+			}]
+			x: -1.0d
+			y: -9.0d
+		}
+		{
+			description: ["Gotta have some screws to secure the Double Tungstensteel Plating. Im sure these will make things very secure."]
+			id: "59A7880359BB5698"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "20FCEB32A52C0817"
+				table_id: 6202000790833671070L
+				type: "loot"
+			}]
+			subtitle: "Screws for Plates"
+			tasks: [{
+				id: "6406939D8B04D5B5"
+				item: "gtceu:tungsten_steel_screw"
+				type: "item"
+			}]
+			x: 1.0d
+			y: -9.0d
+		}
+		{
+			description: ["We have seen many liquids that are the result of processing by the Fusion Reactor."]
+			id: "61D9E67FFA14A8F8"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "414962860B452B17"
+				table_id: 1818042308417101752L
+				type: "loot"
+			}]
+			subtitle: "Oxygen Plasma"
+			tasks: [{
+				id: "0DAF912DAF6215D1"
+				item: "gtceu:oxygen_plasma_bucket"
+				type: "item"
+			}]
+			x: -1.5d
+			y: -8.0d
+		}
+		{
+			description: ["Did you know that plasma is considered the 4th state of Matter next to Solid, Liquid, and Gaseous?"]
+			id: "583F0F3C00D211BE"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "6CF14D0DE98A69F5"
+				table_id: 1818042308417101752L
+				type: "loot"
+			}]
+			subtitle: "Nitrogen Plasma"
+			tasks: [{
+				id: "24B5BC6C1ADADCDB"
+				item: "gtceu:nitrogen_plasma_bucket"
+				type: "item"
+			}]
+			x: -1.5d
+			y: -7.0d
+		}
+		{
+			description: ["Argon is a chemical element; it has symbol Ar and atomic number 18. It is in group 18 of the periodic table and is a noble gas. Argon is the third most abundant gas in Earth's atmosphere, at 0.934% (9340 ppmv)"]
+			id: "539D5084283C6219"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "01ABAB52334C558F"
+				table_id: 1818042308417101752L
+				type: "loot"
+			}]
+			subtitle: "Argon Plasma"
+			tasks: [{
+				id: "6B5A8A12A5C6FA8B"
+				item: "gtceu:argon_plasma_bucket"
+				type: "item"
+			}]
+			x: 1.5d
+			y: -8.0d
+		}
+		{
+			description: ["Of all the elements, Helium is the most stable; it will not burn or react with other elements. Helium has the lowst melting point and boiling points. It exists as a gas, except under extreme conditions where it can be transitioned into the 4th State of Matter, Plasma."]
+			id: "008DBEF8893F1B63"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "7AD360C9FA590EA9"
+				table_id: 1818042308417101752L
+				type: "loot"
+			}]
+			subtitle: "Helium Plasma"
+			tasks: [{
+				id: "5770806D18629209"
+				item: "gtceu:helium_plasma_bucket"
+				type: "item"
+			}]
+			x: 1.5d
+			y: -7.0d
+		}
+		{
+			dependencies: [
+				"12B041E34F58FDD2"
+				"1060C764347CC243"
+				"350B4AC4ADF7F84B"
+				"65A966D22EC7F9AA"
+			]
+			description: [
+				"Saying that this is a massive multiblock structure is an understatement. "
+				""
+				"It requires 3213 Atomic Casings, too many to fit in your inventory, so that part was left at 1 in the quest. "
+				""
+				"But the benefits are astounding. So give it a shot. It dual functions as a resource generator, and a power generator. The power gen numbers are insane."
+			]
+			icon: "gtceu:micro_universe_orb"
+			id: "4C33366BAD0256CF"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "2EB688D929E18540"
+				table_id: 1193402146821170967L
+				type: "loot"
+			}]
+			shape: "heart"
+			size: 1.6d
+			subtitle: "Huh?"
+			tasks: [
+				{
+					id: "5C4C327EF7C20629"
+					item: "gtceu:micro_universe_orb"
+					type: "item"
+				}
+				{
+					count: 16L
+					id: "382025000E17124F"
+					item: "allthecompressed:atm_star_block_2x"
+					type: "item"
+				}
+				{
+					count: 44L
+					id: "3E9BF312DCCD0CBD"
+					item: "gtceu:fusion_casing_mk3"
+					type: "item"
+				}
+				{
+					count: 134L
+					id: "6A83E5C44427C560"
+					item: "gtceu:fusion_glass"
+					type: "item"
+				}
+				{
+					count: 600L
+					id: "69FDB28A4D98F573"
+					item: "gtceu:superconducting_coil"
+					type: "item"
+				}
+				{
+					id: "241FE00A20514BBE"
+					item: "gtceu:atomic_casing"
+					type: "item"
+				}
+				{
+					count: 28L
+					id: "32DB5277664073F0"
+					item: "kubejs:micro_universe_energy_transmitter"
+					type: "item"
+				}
+				{
+					count: 160L
+					id: "18324DF3EDCE5200"
+					item: "kubejs:micro_universe_focus_lens"
+					type: "item"
+				}
+				{
+					count: 768L
+					id: "22BD6AEC9CA35673"
+					item: "connectedglass:clear_glass_black"
+					type: "item"
+				}
+			]
+			x: 10.0d
+			y: 0.0d
+		}
+		{
+			description: [
+				"A catalyst is needed for this process. "
+				""
+				"The Catalyst will ensure that each operation is able to properly complete. They will also be used in the creation of the controller for the Multiblock"
+			]
+			id: "1060C764347CC243"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "175E9D656476225A"
+				table_id: 8781463007120195614L
+				type: "loot"
+			}]
+			shape: "gear"
+			size: 1.5d
+			subtitle: "We need Cats"
+			tasks: [{
+				id: "056C7886E8C6641D"
+				item: "kubejs:micro_universe_catalyst"
+				type: "item"
+			}]
+			x: 12.0d
+			y: 0.0d
+		}
+		{
+			description: ["This is quite the lot of Neutonium. But, look around. There may be other ways to synthesize the resource."]
+			id: "217FA79B7D4C56CD"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "33204AC9BEE0E0AD"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "A Lot of Neutronium"
+			tasks: [{
+				count: 128L
+				id: "29554C352E94FDBA"
+				item: "gtceu:neutronium_block"
+				type: "item"
+			}]
+			x: -4.5d
+			y: -9.0d
+		}
+		{
+			description: ["Having an optimized method to craft these, that takes minimal time will benefit you as you move forward."]
+			id: "0737D64B0CCAE334"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "26C8921839C7223B"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "Fusion Casings... Again"
+			tasks: [{
+				count: 16L
+				id: "28439B5824F1D69B"
+				item: "gtceu:fusion_casing_mk3"
+				type: "item"
+			}]
+			x: -8.0d
+			y: -8.5d
+		}
+		{
+			description: [
+				"Well technically its more. Weve already used these previously. "
+				""
+				"At least they arent that hard to craft."
+			]
+			id: "44BE268EC7D2689D"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "2EEE06E7FDB89A89"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "MORE Coil?!"
+			tasks: [{
+				count: 16L
+				id: "3827A0218C42F225"
+				item: "gtceu:fusion_coil"
+				type: "item"
+			}]
+			x: -9.5d
+			y: -6.5d
+		}
+		{
+			description: [
+				"More fusion glass. Just this time we need it to craft a component, not for a multiblock. "
+				""
+				"You may want to figure a way to passively produce these..."
+			]
+			id: "754229E1F1D2DA8A"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "5745B99A3DC98390"
+				table_id: 7025454341029952768L
+				type: "loot"
+			}]
+			subtitle: "I prefer the window seat"
+			tasks: [{
+				count: 16L
+				id: "4B5E0984A8670146"
+				item: "gtceu:fusion_glass"
+				type: "item"
+			}]
+			x: -9.0d
+			y: -8.5d
+		}
+		{
+			description: ["Liquid Uranium 235. Lets use this liquid to bind together the other components and craft the Absolute Reaction Plate"]
+			id: "452B3207B6C3A5D7"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "6D703D3006EEF3EB"
+				table_id: 7025454341029952768L
+				type: "loot"
+			}]
+			subtitle: "U235"
+			tasks: [{
+				id: "53B39EA986E22753"
+				item: "gtceu:uranium_235_bucket"
+				type: "item"
+			}]
+			x: -9.5d
+			y: -7.5d
+		}
+		{
+			dependencies: [
+				"04362E2A5C541EC5"
+				"7DDF87A5856F9FE3"
+				"1F733319E9F4DFE5"
+				"3E7EE5FC7863B0B2"
+				"47D201ED115F6D6D"
+				"65B40CBB9C6AD5DF"
+				"5357A140DD05654A"
+				"52F81AFDE2DC39EF"
+			]
+			description: [
+				"If we needed something that could ensure the transmission of every tier, with the highest level of efficiency, what would we get?"
+				""
+				"Maybe combining every Superconductor available into a single cable will do the trick!"
+			]
+			id: "768951FBE8A5C934"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "0FFF6BB4765C0E3A"
+					table_id: 1193402146821170967L
+					type: "loot"
+				}
+				{
+					id: "16470AE441828AF5"
+					item: "reliquary:pedestals/passive/black_passive_pedestal"
+					type: "item"
+				}
+				{
+					id: "05F606E17F62ED7C"
+					item: {
+						Count: 1b
+						id: "gtceu:neutronium_wire_cutter"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								RelocateMinedBlocks: 1b
+							}
+							GT.Tool: {
+								Damage: 0
+								HarvestLevel: 6
+								MaxDamage: 65534
+								ToolSpeed: 184.0f
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+							display: {
+								Name: "{\"text\":\"Champion of Hyper Conductivity\"}"
+							}
+						}
+					}
+					type: "item"
+				}
+			]
+			shape: "square"
+			size: 1.5d
+			subtitle: "Hyperconductivity"
+			tasks: [{
+				id: "5F02434BE29DBE19"
+				item: "kubejs:cable_of_hyperconductivity"
+				type: "item"
+			}]
+			x: -6.0d
+			y: 7.5d
+		}
+		{
+			dependencies: ["12B041E34F58FDD2"]
+			description: ["The GregStar can be broken into Shards. We can then utilize those shards to make one of the most OP items!"]
+			id: "73E639487E878948"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "219DDF99241102C7"
+				table_id: 1193402146821170967L
+				type: "loot"
+			}]
+			shape: "gear"
+			size: 1.6d
+			subtitle: "GregStar Shard"
+			tasks: [{
+				id: "7EA1111B5D68265A"
+				item: "kubejs:greg_star_shard"
+				type: "item"
+			}]
+			x: -9.6d
+			y: 0.0d
+		}
+		{
+			description: [
+				"The Classic ATM Star. You should already be familiar with this, and I am sure you have a process to craft them down pat. "
+				""
+				"This is a breeze for you."
+			]
+			id: "05D6CE1B501F59B5"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "6008E2BF84521863"
+				table_id: 7025454341029952768L
+				type: "random"
+			}]
+			subtitle: "A Star for the component for a Stars Component"
+			tasks: [{
+				id: "5924CB4ADD420BE1"
+				item: "allthetweaks:atm_star"
+				type: "item"
+			}]
+			x: -9.0d
+			y: -3.0d
+		}
+		{
+			description: [
+				"These are complex components to make. Making 1 of them is quite the task, involving many materials and many process lines. "
+				""
+				"Now we need 16 of them to proceed. But I'm sure you are up to the task."
+			]
+			id: "476B99789CA7BD96"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "39D117E511FEA6A3"
+				table_id: 1818042308417101752L
+				type: "random"
+			}]
+			subtitle: "Not A Small Order"
+			tasks: [{
+				count: 16L
+				id: "64278A446E19A8A2"
+				item: "gtceu:energy_cluster"
+				type: "item"
+			}]
+			x: -10.0d
+			y: -3.0d
+		}
+		{
+			description: [
+				"You are going to need a Qty of 4 to proceed. In function these will transform power from UV to UHV power, but we dont need these for power conversion. "
+				""
+				"Its going to be used as a crafting component."
+			]
+			id: "38C0D3A240E43A23"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "45C1F46789F59BAE"
+				table_id: 1818042308417101752L
+				type: "loot"
+			}]
+			subtitle: "Transformers Robots in Disguise"
+			tasks: [{
+				count: 4L
+				id: "4369069D6EB498DD"
+				item: "gtceu:uv_transformer_16a"
+				type: "item"
+			}]
+			x: -10.0d
+			y: -4.0d
+		}
+		{
+			description: [
+				"This may have a lot of Amperage, but we are not interested in the power delivery."
+				""
+				"We need this to craft a component. Im sure you got this one as well."
+			]
+			id: "59908911C4FFF223"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "6EF5F107F9DD7D59"
+				table_id: 1818042308417101752L
+				type: "loot"
+			}]
+			subtitle: "16 Amps"
+			tasks: [{
+				count: 4L
+				id: "6232AE3E658F5F32"
+				item: "gtceu:uv_energy_input_hatch_16a"
+				type: "item"
+			}]
+			x: -9.0d
+			y: -4.0d
+		}
+		{
+			description: ["Making 16 coils may be a tall order. But a necessary one for the GregStar!"]
+			id: "61428FAD831DC213"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "75976E047E93A26D"
+				table_id: 341947171990021391L
+				type: "random"
+			}]
+			subtitle: "16 Coils"
+			tasks: [{
+				count: 16L
+				id: "6587C2960517DCAA"
+				item: "gtceu:uv_voltage_coil"
+				type: "item"
+			}]
+			x: -10.0d
+			y: 2.5d
+		}
+		{
+			description: ["The need for Coils is never ending. While we may not be utilizing these in a multiblock, you can be assured they are going to a good source."]
+			id: "762BD49C9589EB3F"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "7B6FE106F2F38123"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "More Coils?"
+			tasks: [{
+				count: 16L
+				id: "70859C00FCD5D7FD"
+				item: "gtceu:tritanium_coil_block"
+				type: "item"
+			}]
+			x: -11.0d
+			y: 3.0d
+		}
+		{
+			description: ["4 Large Naquadria Batteries will wrap up the required items for this component of the GregStar"]
+			id: "176C06C7593C264E"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "2AE3CE5197F89660"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "Quad Batteries"
+			tasks: [{
+				count: 4L
+				id: "1197FAFBC2C62C30"
+				item: "gtceu:uv_naquadria_battery"
+				type: "item"
+			}]
+			x: -10.0d
+			y: 3.5d
+		}
+		{
+			description: ["16x Mercury Barium Calcium Cuprate wire - Qty 8"]
+			id: "7DDF87A5856F9FE3"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "4DE72A995D810B49"
+				table_id: 822291801189586703L
+				type: "loot"
+			}]
+			subtitle: "HV Superconductor"
+			tasks: [{
+				count: 8L
+				id: "0F4171BC636CD47E"
+				item: "gtceu:mercury_barium_calcium_cuprate_hex_wire"
+				type: "item"
+			}]
+			x: -9.5d
+			y: 7.0d
+		}
+		{
+			description: ["16x Indium Tin Barium Titanium Cuprate Wire - Qty 8"]
+			id: "52F81AFDE2DC39EF"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "7761A8080973D0DE"
+				table_id: 7041264405549027492L
+				type: "loot"
+			}]
+			subtitle: "LuV Superconductor"
+			tasks: [{
+				id: "7D4CC15F7269CDFF"
+				item: "gtceu:indium_tin_barium_titanium_cuprate_hex_wire"
+				type: "item"
+			}]
+			x: -5.5d
+			y: 9.5d
+		}
+		{
+			description: ["16x Manganese Phosphide wires - Qty 8"]
+			id: "04362E2A5C541EC5"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "6712F3890BCA9D07"
+				table_id: 4804065436311136435L
+				type: "loot"
+			}]
+			subtitle: "LV Superconductor"
+			tasks: [{
+				count: 8L
+				id: "4E79400A9BC7370E"
+				item: "gtceu:manganese_phosphide_hex_wire"
+				type: "item"
+			}]
+			x: -9.5d
+			y: 6.0d
+		}
+		{
+			description: ["16x Magnesium Diboride Wire - Qty 8"]
+			id: "1F733319E9F4DFE5"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "6A31323028DBE07A"
+				table_id: 7083859357644513434L
+				type: "loot"
+			}]
+			subtitle: "MV Superconductor"
+			tasks: [{
+				count: 8L
+				id: "395487D6B3ABCC6C"
+				item: "gtceu:magnesium_diboride_hex_wire"
+				type: "item"
+			}]
+			x: -8.5d
+			y: 6.0d
+		}
+		{
+			description: ["16x Enriched Naquadah Trinium Europium Duranide wire - Qty 8"]
+			id: "47D201ED115F6D6D"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "2A561A6003938759"
+				table_id: 1818042308417101752L
+				type: "loot"
+			}]
+			subtitle: "UV Superconductor"
+			tasks: [{
+				id: "7A0CFEE89FBD1882"
+				item: "gtceu:enriched_naquadah_trinium_europium_duranide_hex_wire"
+				type: "item"
+			}]
+			x: -5.5d
+			y: 10.5d
+		}
+		{
+			description: ["16x Uranium Rhodium Dinaquadide wire - Qty 8"]
+			id: "65B40CBB9C6AD5DF"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "6590E694F5ABD152"
+				table_id: 5732951907492768982L
+				type: "loot"
+			}]
+			subtitle: "ZPM Superconductor"
+			tasks: [{
+				id: "1CE36B96C09AFD98"
+				item: "gtceu:uranium_rhodium_dinaquadide_hex_wire"
+				type: "item"
+			}]
+			x: -6.5d
+			y: 10.5d
+		}
+		{
+			description: ["16x Uranium Triplatinum Wire - Qty 8"]
+			id: "5357A140DD05654A"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "6D8FEA3F1ABAF30A"
+				table_id: 5304546381530089504L
+				type: "loot"
+			}]
+			subtitle: "EV Superconductor"
+			tasks: [{
+				count: 8L
+				id: "0614DD90A7665C68"
+				item: "gtceu:uranium_triplatinum_hex_wire"
+				type: "item"
+			}]
+			x: -8.5d
+			y: 7.0d
+		}
+		{
+			description: ["16x Samarium Iron Arsenic Oxide wire - Qty 8"]
+			id: "3E7EE5FC7863B0B2"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "442831D834446D4F"
+				table_id: 6202000790833671070L
+				type: "loot"
+			}]
+			subtitle: "IV Superconductor"
+			tasks: [{
+				id: "5B4622DEC901669B"
+				item: "gtceu:samarium_iron_arsenic_oxide_hex_wire"
+				type: "item"
+			}]
+			x: -6.5d
+			y: 9.5d
+		}
+		{
+			description: ["Do you feel like you are levitating yet? Might be all that shulker from that Soul Vial."]
+			id: "5AAD0E516762BA53"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "78E707F77E0FDC15"
+				table_id: 7025454341029952768L
+				type: "loot"
+			}]
+			subtitle: "Prescient Crystal"
+			tasks: [{
+				id: "470B547A16790A4F"
+				item: "enderio:prescient_crystal"
+				type: "item"
+			}]
+			x: 9.5d
+			y: -6.5d
+		}
+		{
+			description: ["Use 3 other crystals to craft this crystal. "]
+			id: "3673893C88EB5EDE"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "3EAD198D95EDDECA"
+				table_id: 7025454341029952768L
+				type: "loot"
+			}]
+			subtitle: "Weathering the Storm"
+			tasks: [{
+				id: "218BDC8B0562A54A"
+				item: "enderio:weather_crystal"
+				type: "item"
+			}]
+			x: 9.5d
+			y: -5.5d
+		}
+		{
+			description: ["Tier 3 Ender IO Exchanger Core. This is the top of the line when it comes to the EnderIO Exchanger Cores."]
+			id: "70B518EC050678AE"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "2B503B2AD1134FB3"
+				table_id: 7025454341029952768L
+				type: "loot"
+			}]
+			subtitle: "Top Tier Exchanger"
+			tasks: [{
+				id: "22436C76962DB59C"
+				item: "exchangers:eio_exchanger_core_tier3"
+				type: "item"
+			}]
+			x: 10.5d
+			y: -6.0d
+		}
+		{
+			dependencies: ["73E639487E878948"]
+			description: ["Making Antimatter is always a challenge. Process lines, the time to process, and the power. This will check off one of those items that will no longer be a concern."]
+			id: "48576E17428906E7"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "259336BEEDD70B1B"
+				table_id: 7175652334583451871L
+				type: "loot"
+			}]
+			shape: "heart"
+			size: 1.75d
+			subtitle: "Creative Chemicals"
+			tasks: [{
+				id: "16816C057E91438E"
+				item: "mekanism:creative_chemical_tank"
+				type: "item"
+			}]
+			x: -12.0d
+			y: 0.0d
+		}
+		{
+			description: [
+				"The Micro Universe Orb requires a lot of power to operate. This power needs to be conentrated to best utilize it for the operataions."
+				""
+				"To achieve this, the structure needs Focus Lenses. "
+			]
+			id: "65A966D22EC7F9AA"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "06924FCA3F701C58"
+				table_id: 8781463007120195614L
+				type: "loot"
+			}]
+			shape: "gear"
+			size: 1.5d
+			subtitle: "Focused Energy"
+			tasks: [{
+				id: "0A648B31D7BC4544"
+				item: "kubejs:micro_universe_focus_lens"
+				type: "item"
+			}]
+			x: 10.0d
+			y: -2.0d
+		}
+		{
+			description: [
+				"With the power requirements of the structure, something is needed to ensure the energy can be transmitted properly."
+				""
+				"These Energy Transmitters will do the trick."
+			]
+			id: "350B4AC4ADF7F84B"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "39FCD56A1BAFB22D"
+				table_id: 8781463007120195614L
+				type: "loot"
+			}]
+			shape: "gear"
+			size: 1.5d
+			subtitle: "Utilizing the Power"
+			tasks: [{
+				id: "1B02FFA5C727B8BC"
+				item: "kubejs:micro_universe_energy_transmitter"
+				type: "item"
+			}]
+			x: 10.0d
+			y: 2.0d
+		}
+	]
+	title: "GregStar"
+}

--- a/config/ftbquests/quests/chapters/ultra_high_voltage.snbt
+++ b/config/ftbquests/quests/chapters/ultra_high_voltage.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "ultra_high_voltage"
-	group: ""
+	group: "1DA67E79B40AB130"
 	icon: "gtceu:wetware_processor_mainframe"
 	id: "60A9BBC993EB2FD2"
-	order_index: 41
+	order_index: 10
 	quest_links: [ ]
 	quests: [
 		{

--- a/config/ftbquests/quests/chapters/ultra_high_voltage.snbt
+++ b/config/ftbquests/quests/chapters/ultra_high_voltage.snbt
@@ -1,0 +1,1161 @@
+{
+	default_hide_dependency_lines: false
+	default_quest_shape: ""
+	filename: "ultra_high_voltage"
+	group: ""
+	icon: "gtceu:wetware_processor_mainframe"
+	id: "60A9BBC993EB2FD2"
+	order_index: 41
+	quest_links: [ ]
+	quests: [
+		{
+			description: [
+				"I know it seems odd that we Finished off the last section and started this section with just the Supercomputer. But there is a reason for that."
+				""
+				"There were components that are needed for the Wetware Processor Mainframe, which will be covered in this section. "
+			]
+			id: "2EA74A823D55D472"
+			rewards: [{
+				id: "138C41B0779E8FD9"
+				type: "xp"
+				xp: 1000
+			}]
+			shape: "diamond"
+			size: 1.5d
+			subtitle: "Wheres the Main Frame?"
+			tasks: [{
+				id: "393B796BC1144684"
+				item: "gtceu:wetware_processor_computer"
+				type: "item"
+			}]
+			x: -15.0d
+			y: -1.0d
+		}
+		{
+			dependencies: [
+				"3D89F65537D7CA1E"
+				"69B74D404B331A14"
+				"2555BA914C466B5C"
+				"0CBF5A49066468DD"
+			]
+			description: ["So much of the work that has been done was directly to support being able to construct the &n&l&5Star Forge!&r&r&r"]
+			icon: "gtceu:star_forge"
+			id: "7AE6AF0B5D3390E7"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "1B8BCAA279AE6AF3"
+				table_id: 8781463007120195614L
+				type: "loot"
+			}]
+			shape: "heart"
+			size: 2.0d
+			subtitle: "Crafting the Cosmos"
+			tasks: [
+				{
+					id: "618354EF9636D820"
+					item: "gtceu:star_forge"
+					type: "item"
+				}
+				{
+					count: 6L
+					id: "454F7D74D75CD02E"
+					item: "mekanism:supercharged_coil"
+					type: "item"
+				}
+				{
+					count: 38L
+					id: "73DEF8CD08315211"
+					item: "gtceu:superconducting_coil"
+					type: "item"
+				}
+				{
+					count: 64L
+					id: "333856BA249BF370"
+					item: "gtceu:trinium_coil_block"
+					type: "item"
+				}
+				{
+					count: 225L
+					id: "5B999D1E4E018709"
+					item: "gtceu:atomic_casing"
+					type: "item"
+				}
+				{
+					count: 224L
+					id: "084BFE437F0F086D"
+					item: "connectedglass:clear_glass_black"
+					type: "item"
+				}
+				{
+					id: "34D497643849738F"
+					item: "allthetweaks:atm_star_block"
+					type: "item"
+				}
+				{
+					icon: "ftbquests:barrier"
+					id: "5D68D1F844ED048B"
+					observe_type: 0
+					timer: 0L
+					to_observe: "gtceu:star_forge"
+					type: "observation"
+				}
+			]
+			x: -5.0d
+			y: -5.5d
+		}
+		{
+			dependencies: [
+				"3D89F65537D7CA1E"
+				"51DBD03FB5F3E26F"
+				"6E18951E41103391"
+				"2555BA914C466B5C"
+			]
+			description: [
+				"Yes. We have Fusion Reactors Mk.I Mk.II and Mk.III. Now there is the Mega Fusion Reactor. "
+				""
+				"All play their own parts, and all are vital to us moving forwards. So again, get at it, and Make yourself the Mega Fusion Reactor. "
+			]
+			icon: "gtceu:mega_fusion_reactor"
+			id: "39CD35C91F07258C"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "3F44AB57C50B81A8"
+				table_id: 8781463007120195614L
+				type: "loot"
+			}]
+			shape: "gear"
+			size: 1.6d
+			subtitle: "Mega Fusion Reactor"
+			tasks: [
+				{
+					id: "6B99152931C28CF4"
+					item: "gtceu:mega_fusion_reactor"
+					type: "item"
+				}
+				{
+					id: "38001A0BC813A12F"
+					item: "mekanism:supercharged_coil"
+					type: "item"
+				}
+				{
+					id: "15645CCCFD36B3FD"
+					item: "gtceu:fusion_glass"
+					type: "item"
+				}
+				{
+					id: "1DF6ABF3DEA03113"
+					item: "gtceu:fusion_casing_mk3"
+					type: "item"
+				}
+				{
+					id: "1CEE1CF49EB683A2"
+					item: "gtceu:fusion_coil"
+					type: "item"
+				}
+				{
+					id: "2F1FE1A604A2BF82"
+					item: "gtceu:tritanium_coil_block"
+					type: "item"
+				}
+				{
+					id: "2952CCEFEE9245AB"
+					item: "gtceu:atomic_casing"
+					type: "item"
+				}
+				{
+					id: "11920FFB5235E181"
+					item: "gtceu:heatproof_machine_casing"
+					type: "item"
+				}
+				{
+					icon: "ftbquests:barrier"
+					id: "271B87AFF66246B5"
+					observe_type: 0
+					timer: 0L
+					to_observe: "gtceu:mega_fusion_reactor"
+					type: "observation"
+				}
+			]
+			x: -13.0d
+			y: -5.5d
+		}
+		{
+			dependencies: ["2B8E66760514BE77"]
+			description: [
+				"The Fusion Reactor Mk. III. Im sure you have already seen what is to come. So you understand that parts of this is necessary. "
+				""
+				"While that is true of whats to come, that doesnt mean the Mk.III isnt of value to us in its intended use. "
+				""
+				"Make at least 1 Mk.III Reactor. It will serve you well."
+			]
+			id: "6E18951E41103391"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "689AC54A19B9EE50"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "Mk. III"
+			tasks: [
+				{
+					id: "1786D0D015C3884C"
+					item: "gtceu:uv_fusion_reactor"
+					type: "item"
+				}
+				{
+					count: 16L
+					id: "4E15B886A44A5574"
+					item: "gtceu:uv_energy_input_hatch"
+					type: "item"
+				}
+				{
+					count: 16L
+					id: "5192F226B2AF2787"
+					item: "gtceu:uv_output_hatch"
+					type: "item"
+				}
+				{
+					count: 16L
+					id: "56277CAE203BB9F4"
+					item: "gtceu:uv_input_hatch"
+					type: "item"
+				}
+				{
+					count: 79L
+					id: "272F201D0A7BA036"
+					item: "gtceu:fusion_casing_mk3"
+					type: "item"
+				}
+				{
+					count: 4L
+					id: "4700909D84885E86"
+					item: "gtceu:fusion_coil"
+					type: "item"
+				}
+			]
+			x: -14.5d
+			y: -5.5d
+		}
+		{
+			dependencies: ["69B74D404B331A14"]
+			description: [
+				"Yes, it may seem odd to Craft the UV tier Circuit Assembler, since the Mainframe used the Assembly Line, but this will be incredibly beneficial."
+				""
+				"The UV Circuit Assembler will allow you to craft 4x LuV Wetware Processors in 1 craft! Thats a huge savings and double the return!"
+			]
+			id: "0CBF5A49066468DD"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "7D7A9F44A20C359E"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "Do we Need this?"
+			tasks: [{
+				id: "3C9575096E4E44E0"
+				item: "gtceu:uv_circuit_assembler"
+				type: "item"
+			}]
+			x: -5.0d
+			y: -1.0d
+		}
+		{
+			dependencies: ["1DBC5E74958A62E6"]
+			description: [
+				"UHV Energy Hatch. We have finally reached the Pinnacle of Energy Hatches!"
+				""
+				"Now we can set our Multiblocks up to be able to processes any tier of power requirements!"
+			]
+			id: "5561EB1E3DD77EC5"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "2B3038B536DADF24"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "Finally at the Top"
+			tasks: [{
+				id: "3009E94D530487D4"
+				item: "gtceu:uhv_energy_input_hatch"
+				type: "item"
+			}]
+			x: -6.5d
+			y: 0.0d
+		}
+		{
+			dependencies: ["5561EB1E3DD77EC5"]
+			description: [
+				"While the UHV Energy Hatch is the Pinnacle of Energy Delivery, we still have the 4A UHV Energy Hatch."
+				""
+				"And yes, this follows the same function as the previous Tiers, and will act like 2x Energy Hatches allowing you to power at a Higher Level."
+			]
+			id: "6F8E58FF4D96C4BC"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "6E7C3514A700FF15"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "Wait... I thought we were at the top?"
+			tasks: [{
+				id: "5D50568CB2796302"
+				item: "gtceu:uhv_energy_input_hatch_4a"
+				type: "item"
+			}]
+			x: -5.5d
+			y: 0.0d
+		}
+		{
+			dependencies: [
+				"2B8E66760514BE77"
+				"454F2BF7F2E25D83"
+			]
+			description: [
+				"Those other Battery companies have nothing on this!"
+				""
+				"This is the Ultimate Battery, and its UHV Tier! For all your power hungry devices (at UHV tier of course)"
+			]
+			id: "0DB92C70D04725BE"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "6D073546ECACAEB6"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "Duracell Eat your heart out"
+			tasks: [{
+				id: "5103FF4986087F40"
+				item: "gtceu:max_battery"
+				type: "item"
+			}]
+			x: -16.5d
+			y: -4.0d
+		}
+		{
+			dependencies: ["337B492F974628A4"]
+			description: [
+				"These monster Coils are the end of the line for coils. "
+				""
+				"With these Coils we can now processes the UHV Superconductors, and finally make them into ingots! "
+			]
+			id: "44EE336BC265D21C"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "48D1C1DAECEAAB94"
+				table_id: 341947171990021391L
+				type: "random"
+			}]
+			subtitle: "Tritanium Coils"
+			tasks: [{
+				id: "204D0E0D57E23E89"
+				item: "gtceu:tritanium_coil_block"
+				type: "item"
+			}]
+			x: -11.5d
+			y: -1.0d
+		}
+		{
+			description: [
+				"Well if 64 Parallel processes werent enough, how about 256? Because thats exactly what this block does. It allows you to run 256 Parallel tasks!"
+				""
+				"This is the highest tier Parallel Control Hatch there is!"
+			]
+			id: "0D59094D0C23C44F"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "28EC4958E4D86290"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "64 Wasnt enough?"
+			tasks: [{
+				id: "685632AB2A3AFA5C"
+				item: "gtceu:uv_parallel_hatch"
+				type: "item"
+			}]
+			x: -10.5d
+			y: 1.0d
+		}
+		{
+			description: [
+				"The UV Field Generator is the last Field Generator you will be building. "
+				""
+				"Plan accordingly to craft a fair amount of these."
+			]
+			id: "3D89F65537D7CA1E"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "379BAF8D63EAA251"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "Last Field Generator"
+			tasks: [{
+				id: "26F1CE1C23672A2A"
+				item: "gtceu:uv_field_generator"
+				type: "item"
+			}]
+			x: -8.0d
+			y: -5.5d
+		}
+		{
+			dependencies: [
+				"3D89F65537D7CA1E"
+				"69B74D404B331A14"
+				"089D22E6B361EBA4"
+			]
+			description: ["While we wont necessarily be utilizing this ship immediately, it would be better to get it crafted now, and have it on stand by for when we are ready to use it."]
+			id: "7ADFAC678D21E6B8"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "461318EE614DBFC9"
+				table_id: 8781463007120195614L
+				type: "loot"
+			}]
+			subtitle: "One Epic Ship"
+			tasks: [{
+				id: "5AF88AB39AF171DE"
+				item: "kubejs:micro_universe_drill_ship"
+				type: "item"
+			}]
+			x: -8.0d
+			y: -3.5d
+		}
+		{
+			dependencies: [
+				"51DBD03FB5F3E26F"
+				"2EA74A823D55D472"
+			]
+			description: [
+				"Great! Now we can craft the UHV Hull. "
+				""
+				"But there doesnt seem to be UHV Machines. Why do we need this hull? Well for the Hatches and Buses of course!"
+			]
+			id: "337B492F974628A4"
+			rewards: [{
+				id: "2504A95AFC702921"
+				item: "gtceu:uhv_machine_hull"
+				type: "item"
+			}]
+			subtitle: "Wheres the Machines?"
+			tasks: [{
+				id: "10FC27F148761FA1"
+				item: "gtceu:uhv_machine_hull"
+				type: "item"
+			}]
+			x: -13.0d
+			y: -1.0d
+		}
+		{
+			description: ["Now these are some high tier plates! But its reasonable for the Highest tier Machine Hull to require the highest tier plates."]
+			id: "51DBD03FB5F3E26F"
+			rewards: [{
+				count: 8
+				id: "525141329895304D"
+				item: "gtceu:neutronium_plate"
+				random_bonus: 8
+				type: "item"
+			}]
+			subtitle: "High Quality Plates"
+			tasks: [{
+				id: "51F75BD7EA96A2A7"
+				item: "gtceu:neutronium_plate"
+				type: "item"
+			}]
+			x: -13.0d
+			y: -2.0d
+		}
+		{
+			dependencies: ["702CE73E39E4D4BD"]
+			description: [
+				"Just like all the other tiers, the UHV tier has its own Superconductor wire. "
+				""
+				"Thats exactly what we have here. "
+			]
+			id: "69B74D404B331A14"
+			rewards: [{
+				count: 4
+				id: "45ACB50EC233BEB8"
+				item: "gtceu:ruthenium_trinium_americium_neutronate_single_wire"
+				random_bonus: 8
+				type: "item"
+			}]
+			subtitle: "UHV Superconductor"
+			tasks: [{
+				id: "46C18FB5D95D423F"
+				item: "gtceu:ruthenium_trinium_americium_neutronate_single_wire"
+				type: "item"
+			}]
+			x: -8.0d
+			y: -1.0d
+		}
+		{
+			description: ["Preparing components for the Micro Universe Drill Ship."]
+			id: "089D22E6B361EBA4"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "0362B4A318F18771"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "Thrusters to Full!"
+			tasks: [
+				{
+					id: "43C5FD69AD640DC2"
+					item: "gtceu:advanced_power_thruster"
+					type: "item"
+				}
+				{
+					id: "388507895A3EC71E"
+					item: "gtceu:hsse_drill_head"
+					type: "item"
+				}
+			]
+			x: -9.5d
+			y: -3.5d
+		}
+		{
+			dependencies: ["44EE336BC265D21C"]
+			description: [
+				"This is one complex ingot. We have many different metals mixed into this alloy. But for good reason."
+				""
+				"With this ingot, now we can make some high tier components!"
+			]
+			id: "702CE73E39E4D4BD"
+			rewards: [{
+				count: 4
+				id: "1ED0731892366C24"
+				item: "gtceu:ruthenium_trinium_americium_neutronate_ingot"
+				random_bonus: 8
+				type: "item"
+			}]
+			subtitle: "Things are complicated..."
+			tasks: [{
+				id: "2EDA6683F4114183"
+				item: "gtceu:ruthenium_trinium_americium_neutronate_ingot"
+				type: "item"
+			}]
+			x: -10.0d
+			y: -1.0d
+		}
+		{
+			dependencies: ["44EE336BC265D21C"]
+			description: [
+				"Again we visit yet another very complex Alloy. "
+				""
+				"But as weve seen with other complex alloys, they are always extremeley beneficial to us, though complicated. This one is no different."
+			]
+			id: "30954ADF34DB05A7"
+			rewards: [{
+				count: 8
+				id: "09A65B9DDFB8CFF3"
+				item: "gtceu:enriched_naquadah_trinium_europium_duranide_ingot"
+				random_bonus: 8
+				type: "item"
+			}]
+			subtitle: "Complex Alloy"
+			tasks: [{
+				id: "20552163E8FFCF03"
+				item: "gtceu:enriched_naquadah_trinium_europium_duranide_ingot"
+				type: "item"
+			}]
+			x: -11.5d
+			y: -4.0d
+		}
+		{
+			dependencies: ["69B74D404B331A14"]
+			description: [
+				"Take the UHV superconductor wire we just made and craft it into a 2x."
+				""
+				"We need the 2x version for our next items we will be crafting up."
+			]
+			id: "1DBC5E74958A62E6"
+			rewards: [{
+				count: 4
+				id: "28994BA3975D3E62"
+				item: "gtceu:ruthenium_trinium_americium_neutronate_double_wire"
+				random_bonus: 8
+				type: "item"
+			}]
+			subtitle: "Double It an pass it to the next person"
+			tasks: [{
+				id: "254F1C854907FCD7"
+				item: "gtceu:ruthenium_trinium_americium_neutronate_double_wire"
+				type: "item"
+			}]
+			x: -8.0d
+			y: 0.0d
+		}
+		{
+			dependencies: [
+				"009041EBAD28D526"
+				"0D59094D0C23C44F"
+			]
+			description: [
+				"Im sure you have made a whole lot of EBF's during your journey to get here."
+				""
+				"There is a whole lot more to go. But now,  you can make yourself a Rotary Hearth Furnace, and get some Parallel tasks running! Lets speed that processing up!"
+			]
+			icon: "gtceu:mega_blast_furnace"
+			id: "625B5E3CDDAECFFD"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "72E4BA4940848225"
+				table_id: 8781463007120195614L
+				type: "loot"
+			}]
+			shape: "gear"
+			size: 1.0d
+			subtitle: "Massive EBF!"
+			tasks: [
+				{
+					id: "66D7D97C3FAA17D4"
+					item: "gtceu:mega_blast_furnace"
+					type: "item"
+				}
+				{
+					count: 132L
+					id: "0F5FC4C9058975BD"
+					item: "gtceu:naquadah_alloy_frame"
+					type: "item"
+				}
+				{
+					count: 28L
+					id: "7541ECC2507CE71C"
+					item: "gtceu:tungstensteel_firebox_casing"
+					type: "item"
+				}
+				{
+					count: 40L
+					id: "11597D8C8B61CF67"
+					item: "gtceu:extreme_engine_intake_casing"
+					type: "item"
+				}
+				{
+					count: 96L
+					id: "06C01CB26C01E667"
+					item: "gtceu:cupronickel_coil_block"
+					type: "item"
+				}
+				{
+					count: 72L
+					id: "7B2A32F3AA195AB7"
+					item: "gtceu:tungstensteel_pipe_casing"
+					type: "item"
+				}
+				{
+					count: 20L
+					id: "17C7595ADF6B7BAB"
+					item: "gtceu:heat_vent"
+					type: "item"
+				}
+				{
+					count: 382L
+					id: "727FA76459DBE141"
+					item: "gtceu:high_temperature_smelting_casing"
+					type: "item"
+				}
+				{
+					count: 88L
+					id: "30BE3BCD9E872FB8"
+					item: "gtceu:robust_machine_casing"
+					type: "item"
+				}
+				{
+					icon: "ftbquests:barrier"
+					id: "647F2A845A62F6B6"
+					observe_type: 0
+					timer: 0L
+					title: "Observe a Rotary Hearth Furnace"
+					to_observe: "gtceu:rotary_hearth_furnace"
+					type: "observation"
+				}
+			]
+			x: -9.0d
+			y: 0.5d
+		}
+		{
+			dependencies: [
+				"009041EBAD28D526"
+				"0D59094D0C23C44F"
+			]
+			description: [
+				"Now, with all those processing tasks being done by your new Rotary Hearth Furnace, you are going to need a multiblock that can keep up in cooling down your ingots."
+				""
+				"Thats where the Bulk Blast Chiller comes into play!"
+			]
+			icon: "gtceu:mega_vacuum_freezer"
+			id: "67AA17BCDE37DFAB"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "23F4A6D4A8E87215"
+				table_id: 8781463007120195614L
+				type: "loot"
+			}]
+			shape: "gear"
+			subtitle: "Pairs well with the RHF"
+			tasks: [
+				{
+					id: "28EEC6756486D379"
+					item: "gtceu:mega_vacuum_freezer"
+					type: "item"
+				}
+				{
+					count: 74L
+					id: "1237C1C3D4F81E76"
+					item: "gtceu:tungstensteel_pipe_casing"
+					type: "item"
+				}
+				{
+					count: 26L
+					id: "33A1A44710F78A0D"
+					item: "gtceu:heat_vent"
+					type: "item"
+				}
+				{
+					count: 9L
+					id: "21CC962B100848B4"
+					item: "gtceu:tempered_glass"
+					type: "item"
+				}
+				{
+					count: 36L
+					id: "613FCC5D29BA60B8"
+					item: "gtceu:clean_machine_casing"
+					type: "item"
+				}
+				{
+					count: 154L
+					id: "068B1FF9F58C3C18"
+					item: "gtceu:frostproof_machine_casing"
+					type: "item"
+				}
+				{
+					icon: "ftbquests:barrier"
+					id: "3DCD4DD728EB87C6"
+					observe_type: 0
+					timer: 0L
+					to_observe: "gtceu:bulk_blast_chiller"
+					type: "observation"
+				}
+			]
+			x: -9.0d
+			y: 1.5d
+		}
+		{
+			dependencies: ["1DBC5E74958A62E6"]
+			description: [
+				"While this does take up quite a bit of the UHV Superconductors we just made, its absolutely necessary."
+				""
+				"Trust me, you will be glad to have crafted these once you see what they are going to be used for."
+			]
+			id: "009041EBAD28D526"
+			rewards: [{
+				count: 4
+				id: "7D0C9B8FF1D6847E"
+				item: "gtceu:ruthenium_trinium_americium_neutronate_quadruple_wire"
+				random_bonus: 8
+				type: "item"
+			}]
+			subtitle: "Now were at 4x"
+			tasks: [{
+				id: "752C8E0366A00BB3"
+				item: "gtceu:ruthenium_trinium_americium_neutronate_quadruple_wire"
+				type: "item"
+			}]
+			x: -8.0d
+			y: 1.0d
+		}
+		{
+			dependencies: ["30954ADF34DB05A7"]
+			description: [
+				"Now we have the UV Superconductor Wire! Used to craft many different components, some of which are necessary for us to proceed. "
+				""
+				"More Wires.... Yay."
+			]
+			id: "2B8E66760514BE77"
+			rewards: [{
+				count: 8
+				id: "46ACF990FF292361"
+				item: "gtceu:enriched_naquadah_trinium_europium_duranide_single_wire"
+				random_bonus: 16
+				type: "item"
+			}]
+			subtitle: "UV Superconductor"
+			tasks: [{
+				id: "6C4C914784FB64DC"
+				item: "gtceu:enriched_naquadah_trinium_europium_duranide_single_wire"
+				type: "item"
+			}]
+			x: -14.5d
+			y: -4.0d
+		}
+		{
+			description: [
+				"While this may be one of the more complex crafts, having a crafting life spanning numerous Tiers, it is a required item. "
+				""
+				"Yes, Theres a lot that goes into making 1 of these, but try optimizing the Crafting path. Trust, youll give thanks afterwards."
+			]
+			id: "454F2BF7F2E25D83"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "35C2A7CABA21D940"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "Compex Energy"
+			tasks: [{
+				id: "0B711F2A4A5DCE95"
+				item: "gtceu:energy_cluster"
+				type: "item"
+			}]
+			x: -16.5d
+			y: -5.5d
+		}
+		{
+			dependencies: ["3D40D91D7D948714"]
+			description: ["I am sure that  you now see why these plates will be vital. But as you already know, they will provide a great benefit."]
+			id: "2555BA914C466B5C"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "5C723C9FAE82468A"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "The Best Casing"
+			tasks: [{
+				id: "3DF016CBFB16E05C"
+				item: "gtceu:atomic_casing"
+				type: "item"
+			}]
+			x: -8.0d
+			y: -7.5d
+		}
+		{
+			dependencies: ["7F5DAB3EDB6E9592"]
+			description: ["There is going to be a high demand for these plates. Figuring out how to supply yourself with a bunch of these plates may be a challenge, but well worth it."]
+			id: "3D40D91D7D948714"
+			rewards: [{
+				count: 4
+				id: "3893B82B1CA8161B"
+				item: "gtceu:trinaquadalloy_plate"
+				random_bonus: 4
+				type: "item"
+			}]
+			subtitle: "The dishes Plating matters"
+			tasks: [{
+				id: "5137EB9F0E75A746"
+				item: "gtceu:trinaquadalloy_plate"
+				type: "item"
+			}]
+			x: -6.5d
+			y: -7.5d
+		}
+		{
+			dependencies: ["0CF6D11016BAF3D0"]
+			description: [
+				"There is going to be a lot of Trinaquah being made."
+				""
+				"Figuring out how to optimize the process for speed and efficiency will probably be necessary."
+			]
+			id: "7F5DAB3EDB6E9592"
+			rewards: [{
+				count: 4
+				id: "7A29C802031CEB87"
+				item: "gtceu:trinaquadalloy_ingot"
+				random_bonus: 4
+				type: "item"
+			}]
+			subtitle: "Cooling Alloys"
+			tasks: [{
+				id: "74258E10C48FAA93"
+				item: "gtceu:trinaquadalloy_ingot"
+				type: "item"
+			}]
+			x: -5.0d
+			y: -7.5d
+		}
+		{
+			description: ["Now we are producing some complex Naquadah. Just like all the other complex resources we are working on, this one provides a significant benefit to the factor."]
+			id: "0CF6D11016BAF3D0"
+			rewards: [{
+				id: "7BB30A393756D2D3"
+				item: {
+					Count: 1b
+					ForgeCaps: {
+						Parent: {
+							Amount: 16000
+							FluidName: "gtceu:trinaquadalloy"
+							capacity: 16000
+						}
+					}
+					id: "evilcraft:dark_tank"
+					tag: {
+						Fluid: {
+							Amount: 16000
+							FluidName: "gtceu:trinaquadalloy"
+						}
+						capacity: 16000
+					}
+				}
+				type: "item"
+			}]
+			subtitle: "Complex Naquadah"
+			tasks: [{
+				id: "747C0465749AAB2C"
+				item: "gtceu:trinaquadalloy_bucket"
+				type: "item"
+			}]
+			x: -5.0d
+			y: -9.0d
+		}
+		{
+			dependencies: ["6F8E58FF4D96C4BC"]
+			description: [
+				"You read that right. This is a 16A UHV Energy Hatch. 4x the potencey of the 4A Energy Hatch."
+				""
+				"And it provides all the overclocking you could dream of!"
+			]
+			id: "0DB21D996607BD8D"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "2FDB3BAF2DB98AE3"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "16A UHV Energy Hatch?!"
+			tasks: [{
+				id: "1FE57FC0C5BBD345"
+				item: "gtceu:uhv_energy_input_hatch_16a"
+				type: "item"
+			}]
+			x: -5.5d
+			y: 1.0d
+		}
+		{
+			dependencies: ["0DB21D996607BD8D"]
+			description: ["This has the powerflow your Substations were looking for! Now you can give it All the Amps!"]
+			id: "4576043B8297BDB4"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "25F28455CCB66C56"
+				table_id: 341947171990021391L
+				type: "loot"
+			}]
+			subtitle: "1.21 Gigawatts!"
+			tasks: [{
+				id: "48694D5AFCE1004C"
+				item: "gtceu:uhv_substation_input_hatch_64a"
+				type: "item"
+			}]
+			x: -5.5d
+			y: 2.0d
+		}
+		{
+			dependencies: [
+				"1FEB1ECDDDD8AD0E"
+				"418E02FFE241A734"
+				"79E29CFE2399AE96"
+			]
+			description: [
+				"Now we are talking!"
+				""
+				"Yes, we are not direclty utilizing this immediately. But setting it up now to craft and collect will be very beneficial, and save you a ton of time!"
+			]
+			id: "0A1BACA070EB5264"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "381F47984205C92E"
+					table_id: 341947171990021391L
+					type: "loot"
+				}
+				{
+					id: "3A692A70D38C3533"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							Parent: {
+								Amount: 16000
+								FluidName: "gtceu:star_matter_plasma"
+								capacity: 16000
+							}
+						}
+						id: "evilcraft:dark_tank"
+						tag: {
+							Fluid: {
+								Amount: 16000
+								FluidName: "gtceu:star_matter_plasma"
+							}
+							capacity: 16000
+						}
+					}
+					type: "item"
+				}
+			]
+			subtitle: "Star Matter"
+			tasks: [{
+				id: "5D4E3E64BF2AF1FE"
+				item: "gtceu:star_matter_plasma_bucket"
+				type: "item"
+			}]
+			x: -13.0d
+			y: -10.0d
+		}
+		{
+			description: ["Liquid Iron Plasma may seem like an odd resource, but its necessary for what you are going to make."]
+			id: "1FEB1ECDDDD8AD0E"
+			rewards: [{
+				id: "45C6CD8552FBD30E"
+				item: {
+					Count: 1b
+					ForgeCaps: {
+						Parent: {
+							Amount: 16000
+							FluidName: "gtceu:iron"
+							capacity: 16000
+						}
+					}
+					id: "evilcraft:dark_tank"
+					tag: {
+						Fluid: {
+							Amount: 16000
+							FluidName: "gtceu:iron"
+						}
+						capacity: 16000
+					}
+				}
+				type: "item"
+			}]
+			subtitle: "All"
+			tasks: [{
+				id: "3E9D00BCF9710B1B"
+				item: "gtceu:iron_bucket"
+				type: "item"
+			}]
+			x: -14.0d
+			y: -9.0d
+		}
+		{
+			dependencies: ["2C9DDB3AAA30E02A"]
+			description: ["Liquid Helium Plasma. Ensure your processing lines are making enough Helium"]
+			id: "418E02FFE241A734"
+			rewards: [{
+				id: "3437B1764F2C8CB3"
+				item: {
+					Count: 1b
+					ForgeCaps: {
+						Parent: {
+							Amount: 16000
+							FluidName: "gtceu:helium_plasma"
+							capacity: 16000
+						}
+					}
+					id: "evilcraft:dark_tank"
+					tag: {
+						Fluid: {
+							Amount: 16000
+							FluidName: "gtceu:helium_plasma"
+						}
+						capacity: 16000
+					}
+				}
+				type: "item"
+			}]
+			subtitle: "The"
+			tasks: [{
+				id: "06BCA11DE67C5D89"
+				item: "gtceu:helium_plasma_bucket"
+				type: "item"
+			}]
+			x: -13.0d
+			y: -9.0d
+		}
+		{
+			description: ["Liquid Oxygen Plasma. We have used a ton of Oxygen by now, but we still have more to use!"]
+			id: "79E29CFE2399AE96"
+			rewards: [{
+				id: "49A3DC24BAC9CCED"
+				item: {
+					Count: 1b
+					ForgeCaps: {
+						Parent: {
+							Amount: 16000
+							FluidName: "gtceu:oxygen_plasma"
+							capacity: 16000
+						}
+					}
+					id: "evilcraft:dark_tank"
+					tag: {
+						Fluid: {
+							Amount: 16000
+							FluidName: "gtceu:oxygen_plasma"
+						}
+						capacity: 16000
+					}
+				}
+				type: "item"
+			}]
+			subtitle: "Plasma"
+			tasks: [{
+				id: "1E765ED0D810792E"
+				item: "gtceu:oxygen_plasma_bucket"
+				type: "item"
+			}]
+			x: -12.0d
+			y: -9.0d
+		}
+		{
+			dependencies: ["39CD35C91F07258C"]
+			description: [
+				"In the next section we are going to need to make a bunch of Micro Universe Catalysts. "
+				""
+				"This component uses Star Matter Plasma to make the Catalysts."
+				""
+				"Although you dont need to make it now, it certainly would be very helpful, since we are going to need a bunch of Star Matter Plasma to make the 16x Catalysts."
+			]
+			id: "2C9DDB3AAA30E02A"
+			rewards: [{
+				id: "1DC2112E52BF01A3"
+				type: "xp"
+				xp: 1000
+			}]
+			subtitle: "Start Now"
+			tasks: [{
+				id: "6F07606E3F7BE160"
+				title: "Jump Start"
+				type: "checkmark"
+			}]
+			x: -13.0d
+			y: -7.5d
+		}
+		{
+			dependencies: ["2B8E66760514BE77"]
+			description: [
+				"You did it!"
+				""
+				"This is it! The Highest tier Processor you can make! "
+				""
+				"But you're not done yet... This may be the last processor, but theres still more to come. Its going to get even more fun from this point on!"
+			]
+			id: "054D2D3C20C2D32F"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "10481F8A04D25540"
+				table_id: 8781463007120195614L
+				type: "loot"
+			}]
+			shape: "gear"
+			size: 1.5d
+			subtitle: "Great Success!!!"
+			tasks: [{
+				id: "61316E46DA048A55"
+				item: "gtceu:wetware_processor_mainframe"
+				type: "item"
+			}]
+			x: -16.5d
+			y: -2.5d
+		}
+	]
+	title: "Ultra High Voltage"
+}

--- a/config/ftbquests/quests/reward_tables/gt_uhv_basic_rewards.snbt
+++ b/config/ftbquests/quests/reward_tables/gt_uhv_basic_rewards.snbt
@@ -1,7 +1,7 @@
 {
 	id: "04BED724266A250F"
 	loot_size: 1
-	order_index: 58
+	order_index: 39
 	rewards: [
 		{ item: "gtceu:wetware_processor_mainframe", weight: 3.0f }
 		{ item: "gtceu:uv_robot_arm", weight: 3.0f }

--- a/config/ftbquests/quests/reward_tables/legendary_gt_rewards.snbt
+++ b/config/ftbquests/quests/reward_tables/legendary_gt_rewards.snbt
@@ -1,0 +1,26 @@
+{
+	id: "79DE06142BA2001E"
+	loot_size: 1
+	order_index: 41
+	rewards: [
+		{ item: "gtceu:wetware_processor_mainframe" }
+		{ item: "gtceu:wetware_processor_computer" }
+		{ item: "gtceu:wetware_processor_assembly" }
+		{ item: "gtceu:wetware_processor" }
+		{ item: "gtceu:uv_energy_input_hatch" }
+		{ item: "gtceu:energy_cluster" }
+		{ item: "gtceu:highly_advanced_soc_wafer" }
+		{ item: "gtceu:ruthenium_trinium_americium_neutronate_ingot" }
+		{ item: "gtceu:enriched_naquadah_trinium_europium_duranide_ingot" }
+		{ item: "gtceu:crystal_soc" }
+		{ item: "gtceu:uv_field_generator" }
+		{ item: "gtceu:tritanium_coil_block" }
+		{ item: "gtceu:fusion_coil" }
+		{ item: "gtceu:zpm_parallel_hatch" }
+		{ item: "gtceu:uv_input_bus" }
+		{ item: "gtceu:uv_output_bus" }
+		{ item: "gtceu:uv_input_hatch" }
+		{ item: "gtceu:uv_output_hatch" }
+	]
+	title: "Legendary GT Rewards"
+}

--- a/config/ftbquests/quests/reward_tables/mythic_gt_rewards.snbt
+++ b/config/ftbquests/quests/reward_tables/mythic_gt_rewards.snbt
@@ -1,0 +1,21 @@
+{
+	id: "108FD0EDFB76E717"
+	loot_size: 1
+	order_index: 40
+	rewards: [
+		{ count: 2, item: "gtceu:atomic_casing", random_bonus: 4 }
+		{ count: 4, item: "gtceu:enriched_naquadah_trinium_europium_duranide_hex_wire", random_bonus: 4, weight: 8.0f }
+		{ item: "gtceu:max_battery", weight: 3.0f }
+		{ item: "gtceu:uv_parallel_hatch", weight: 6.0f }
+		{ item: "gtceu:uhv_energy_input_hatch", weight: 8.0f }
+		{ count: 4, item: "gtceu:trinaquadalloy_ingot", random_bonus: 4, weight: 6.0f }
+		{ count: 4, item: "gtceu:europium_ingot", random_bonus: 8, weight: 10.0f }
+		{ count: 2, item: "gtceu:superconducting_coil", random_bonus: 2, weight: 10.0f }
+		{ count: 8, item: "gtceu:uhpic_wafer", random_bonus: 8, weight: 12.0f }
+		{ count: 8, item: "gtceu:highly_advanced_soc_wafer", random_bonus: 8, weight: 12.0f }
+		{ item: "gtceu:uv_field_generator", weight: 8.0f }
+		{ count: 2, item: "gtceu:neutronium_block", random_bonus: 2, weight: 6.0f }
+		{ item: "gtceu:uv_energy_input_hatch_16a", weight: 8.0f }
+	]
+	title: "Mythic GT Rewards"
+}

--- a/kubejs/assets/gtceu/lang/en_us.json
+++ b/kubejs/assets/gtceu/lang/en_us.json
@@ -6,11 +6,11 @@
     "gtceu.micro_universe_reactor":"Micro Universe Reactor",
     "gtceu.micro_universe_collector":"Micro Universe Collector",
     "gtceu.mega_fusion_reactor":"Mega Fusion Reactor",
-    "material.inert_nether_essence":"Inert Nether Star Essence",
-    "material.trinaquadalloy": "Trinaquadalloy",
-    "material.fluorite": "Fluorite",
-    "material.dolomite": "Dolomite",
-    "material.star_matter": "Star Matter",
+    "material.gtceu.inert_nether_essence":"Inert Nether Star Essence",
+    "material.gtceu.trinaquadalloy": "Trinaquadalloy",
+    "material.gtceu.fluorite": "Fluorite",
+    "material.gtceu.dolomite": "Dolomite",
+    "material.gtceu.star_matter": "Star Matter",
 	"block.gtceu.advanced_large_chemical_reactor": "Advanced Large Chemical Reactor",
-	"material.nitinol": "Nitinol"
+	"material.gtceu.nitinol": "Nitinol"
 }


### PR DESCRIPTION
I have a completed version of the UHV Quest Chapter as well as a GregStar chapter. 

UHV, while not directly containing UHV machines as there are none, it does cover the components needed to get to the UHV Energy Hatch, and a few other UHV tier components, as well as the Mega Fusion Reactor, and Star Forge. 

I know that the GregStar is a quest in the Creative section, but this is a chapter which guides players through the different items and components needed, which makes up the GregStar as well as the Micro Universe Orb and the GregStar shard. There is a background image that gives the quest chapter a similar feel to the ATM Star chapter. There is a banner that is in the works, but not completed yet, and may take a little bit of time. I can merge in the Banner when it is completed. 

Both Chapters have completed Descriptions and rewards attached. There are 2 different reward tables for the GregStar, Legendary and Mythic, depending on the item being completed. Rewards on the GregStar chapter have also been curated so that items that can be completed earlier in the pack dont receive GT rewards, so as to not bypass progression.

I was trying to get these in before an update was made. Update was made today, but I didnt see a note on Quests being added, so I hope these can be added along with the other ones.