### PR TITLE
disable asyncRecipeSearching in gtceu.yaml

### DIFF
--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -186,6 +186,10 @@ machines:
   # Default: false
   enableTieredCasings: false
 
+  # Whether search for recipes asynchronously.
+  #  Default: true
+  asyncRecipeSearching: false
+
 client:
   # Whether or not to enable Emissive Textures for GregTech Machines.
   # Default: true


### PR DESCRIPTION
Per the comment in Discord pins, this change should fix the voiding of items and multiblock machines getting stuck.  Should be tested to ensure it applies once installed (first time changing anything in a modpack, so apologies if I screwed it up).

Hope this is okay :/