### PR TITLE
Change ad_astra:oxygen_tank to ad_astra:gas_tank in "Preparing Some Oxygen"

### DIFF
--- a/config/ftbquests/quests/chapters/ad_astra.snbt
+++ b/config/ftbquests/quests/chapters/ad_astra.snbt
@@ -766,7 +766,7 @@
 					id: "0DE204C9101E0A72"
 					item: {
 						Count: 1b
-						id: "ad_astra:oxygen_tank"
+						id: "ad_astra:gas_tank"
 						tag: {
 							BotariumData: { }
 						}


### PR DESCRIPTION
The item id for the oxygen tank in the Ad Astra quest-line is wrong.
This PR fixes that.

![image](https://github.com/AllTheMods/ATM-9/assets/38286424/66e60e0d-1809-4e5c-87a5-7bde8e709c16)
