### PR TITLE
Quest Adjustments

### DIFF
--- a/config/ftbquests/quests/chapters/an_introduction.snbt
+++ b/config/ftbquests/quests/chapters/an_introduction.snbt
@@ -407,6 +407,8 @@
 				"Ores generate in veins at varying heights spaced apart by every 3 chunks"
 				""
 				"Ore veins are often comprised of 3 or more different ores"
+				""
+				"All GT Ore veins were moved to the Mining Dimension from every other dimension"
 			]
 			disable_toast: true
 			icon: "minecraft:grass_block"
@@ -418,11 +420,11 @@
 				xp: 10
 			}]
 			tasks: [{
-				id: "6AA2E87093C3A36F"
-				optional_task: true
-				title: "Overworld Ores"
-				type: "checkmark"
+				dimension: "allthemodium:mining"
+				id: "5E966121508B53EA"
+				type: "dimension"
 			}]
+			title: "Overworld Layer Ores"
 			x: -5.5d
 			y: 0.5d
 		}
@@ -2161,7 +2163,7 @@
 			y: 5.5d
 		}
 		{
-			description: ["Every 3 chunks you'll find another ore vein, occasionally lava will prevent a vein from spawning though"]
+			description: ["Every 3 chunks you'll find another ore vein!"]
 			icon: "minecraft:netherrack"
 			id: "0D20644407244A60"
 			rewards: [{
@@ -2170,17 +2172,17 @@
 				xp: 10
 			}]
 			tasks: [{
-				dimension: "minecraft:the_nether"
+				dimension: "allthemodium:mining"
 				id: "500548E772861A58"
-				title: "Go to the Nether"
+				title: "Nether Layer Ores"
 				type: "dimension"
 			}]
-			title: "Nether Ores"
+			title: "Nether Layer Ores"
 			x: 6.0d
 			y: 3.5d
 		}
 		{
-			description: ["3 chunks apart, now with void to cause them not to spawn sometimes! "]
+			description: ["3 chunks apart, in case you didn't know that already"]
 			icon: "minecraft:end_stone"
 			id: "244220A5D9F4C702"
 			rewards: [{
@@ -2189,12 +2191,12 @@
 				xp: 10
 			}]
 			tasks: [{
-				dimension: "minecraft:the_end"
+				dimension: "allthemodium:mining"
 				id: "540231448A4DE43B"
-				title: "Visit the End"
+				title: "End Layer Ores"
 				type: "dimension"
 			}]
-			title: "End Ores"
+			title: "End Layer Ores"
 			x: 6.0d
 			y: -2.5d
 		}

--- a/config/ftbquests/quests/chapters/chapter_2.snbt
+++ b/config/ftbquests/quests/chapters/chapter_2.snbt
@@ -371,11 +371,12 @@
 		}
 		{
 			dependencies: [
-				"6279DD34051D7C78"
 				"6E29BA2E8642AF53"
 				"71B824BEA02C4A34"
 				"5D0C944F84E341BE"
 				"124BDAF91DA74910"
+				"356F450F4ADD22D7"
+				"73EFADE932DFEF86"
 			]
 			id: "73990028197AF1AB"
 			rewards: [
@@ -523,7 +524,6 @@
 				"627A39E62DD49CD8"
 				"709F1FA492703463"
 				"6BDBF4D6086513C1"
-				"356F450F4ADD22D7"
 				"6CD7A3760C6D87E6"
 				"106A3D79B1CDE895"
 				"0A6378C7455E45B1"
@@ -741,9 +741,12 @@
 				type: "loot"
 			}]
 			tasks: [{
-				count: 2L
 				id: "44CFFE38FD3BBED3"
-				item: "occultism:storage_controller"
+				item: {
+					Count: 1b
+					id: "occultism:stable_wormhole"
+					tag: { }
+				}
 				type: "item"
 			}]
 			x: -4.0d
@@ -1065,37 +1068,6 @@
 			y: 11.0d
 		}
 		{
-			dependencies: ["519604E883E6B620"]
-			hide_dependent_lines: true
-			id: "6279DD34051D7C78"
-			rewards: [{
-				exclude_from_claim_all: true
-				id: "2A1B6CD62D0A6473"
-				table_id: 5564196992594175882L
-				type: "loot"
-			}]
-			tasks: [{
-				id: "432B51525158B3C8"
-				item: {
-					Count: 1b
-					id: "industrialforegoing:infinity_nuke"
-					tag: {
-						CanCharge: 1b
-						Energy: 0L
-						Fluid: {
-							Amount: 0
-							FluidName: "biofuel"
-						}
-						Selected: "POOR"
-						Special: 0b
-					}
-				}
-				type: "item"
-			}]
-			x: 6.5d
-			y: 1.5d
-		}
-		{
 			dependencies: ["11B8C5F88DCB3BF5"]
 			description: [
 				"&aPneumaticCraft&r is all about Pressure!"
@@ -1155,6 +1127,7 @@
 		}
 		{
 			dependencies: ["46B515C90C13A72F"]
+			description: ["You didn't hear it from me, but there are some interesting ways to make &5Inert Nether Stars&r which can be turned into Nether Stars"]
 			hide_dependency_lines: true
 			id: "0A37761737B01BFD"
 			rewards: [
@@ -1574,7 +1547,7 @@
 			description: [
 				"&dMekanism&r is a mod that you can start from the beginning, and still be working on it right before you complete the pack."
 				""
-				"To make the Star, you'll need 5 total pieces of &dAnitmatter&r, so you might as well get started soon! Need some help getting started?"
+				"To make the Star, you'll need 5 total pieces of &dAntimatter&r, so you might as well get started soon! Need some help getting started?"
 				""
 				"{\"clickEvent\": {\"action\": \"change_page\", \"value\": \"23983F4DC524B14B\"}, \"text\": \"Click here to start the questline!\", \"color\": \"#55FF55\", \"underlined\": \"true\"}"
 			]
@@ -3479,6 +3452,12 @@
 					type: "xp"
 					xp: 100
 				}
+				{
+					exclude_from_claim_all: true
+					id: "7476D0F37A40883B"
+					table_id: 5564196992594175882L
+					type: "loot"
+				}
 			]
 			shape: "square"
 			tasks: [
@@ -3519,6 +3498,16 @@
 							voidItems: 0b
 						}
 					}
+					type: "item"
+				}
+				{
+					id: "3C5F97640A5789B6"
+					item: "mythicbotany:mjoellnir"
+					type: "item"
+				}
+				{
+					id: "241075340C282F2D"
+					item: "thermal_extra:rf_coil_xfer_augment_5"
 					type: "item"
 				}
 			]

--- a/config/ftbquests/quests/chapters/extreme_voltage.snbt
+++ b/config/ftbquests/quests/chapters/extreme_voltage.snbt
@@ -420,7 +420,6 @@
 		}
 		{
 			dependencies: [
-				"72E5439299E957A8"
 				"0911814AFFFCF885"
 				"6D082AE4CF9A56DC"
 			]
@@ -620,65 +619,6 @@
 			title: "Low Power Integrated Chip"
 			x: 1.0d
 			y: 4.5d
-		}
-		{
-			dependencies: ["358706CA93DC2A9C"]
-			description: [
-				"Use that &eExtractor&r to get your copper in a liquid state"
-				""
-				"&eWire Cut&r the Kanthal ingots"
-				""
-				"&eBend&r that Aluminium"
-				""
-				"Then put it all together in your &eAssembler&r!"
-				""
-				"Replace the Cupronickel Coils on your &aEBF&r with this stuff"
-			]
-			id: "72E5439299E957A8"
-			rewards: [{
-				exclude_from_claim_all: true
-				id: "5C29ED861964C9EC"
-				table_id: 5304546381530089504L
-				type: "loot"
-			}]
-			tasks: [{
-				count: 16L
-				id: "6C8DCC0E471D0163"
-				item: "gtceu:kanthal_coil_block"
-				type: "item"
-			}]
-			x: 3.000000000000001d
-			y: -1.0d
-		}
-		{
-			dependencies: ["1812BF72305CFFCF"]
-			description: ["Cook the dust up in the &aEBF&r and cool it down in the &eChemical Bath&r or &aVacuum Freezer&r"]
-			id: "358706CA93DC2A9C"
-			tasks: [{
-				id: "4E1E15185D672109"
-				item: "gtceu:kanthal_ingot"
-				type: "item"
-			}]
-			x: 3.000000000000001d
-			y: -2.5000000000000004d
-		}
-		{
-			description: ["Put Aluminium dust, Iron dust, and Chromium dust together in a &eMixer&r and watch it blend!"]
-			id: "1812BF72305CFFCF"
-			rewards: [{
-				id: "74819F7F2D53028B"
-				item: "gtceu:chromium_dust"
-				random_bonus: 2
-				type: "item"
-			}]
-			shape: "square"
-			tasks: [{
-				id: "2CF35B15AD75E179"
-				item: "gtceu:kanthal_dust"
-				type: "item"
-			}]
-			x: 3.000000000000001d
-			y: -4.0d
 		}
 		{
 			dependencies: [

--- a/config/ftbquests/quests/chapters/high_voltage.snbt
+++ b/config/ftbquests/quests/chapters/high_voltage.snbt
@@ -39,7 +39,7 @@
 				type: "item"
 			}]
 			x: -7.5d
-			y: 0.0d
+			y: 2.0d
 		}
 		{
 			dependencies: [
@@ -66,7 +66,7 @@
 				type: "item"
 			}]
 			x: 0.0d
-			y: -2.5d
+			y: -0.5d
 		}
 		{
 			dependencies: [
@@ -94,7 +94,7 @@
 				type: "item"
 			}]
 			x: 2.0d
-			y: -2.5d
+			y: -0.5d
 		}
 		{
 			dependencies: [
@@ -120,7 +120,7 @@
 				type: "item"
 			}]
 			x: 4.5d
-			y: -1.0d
+			y: 1.0d
 		}
 		{
 			dependencies: [
@@ -148,7 +148,7 @@
 				type: "item"
 			}]
 			x: 8.5d
-			y: 0.0d
+			y: 2.0d
 		}
 		{
 			dependencies: [
@@ -190,7 +190,7 @@
 				type: "item"
 			}]
 			x: 11.5d
-			y: 0.0d
+			y: 2.0d
 		}
 		{
 			dependencies: ["70C952B8FF3418F6"]
@@ -212,7 +212,7 @@
 				type: "item"
 			}]
 			x: 0.0d
-			y: 0.0d
+			y: 2.0d
 		}
 		{
 			dependencies: [
@@ -258,7 +258,7 @@
 				}
 			]
 			x: 1.0d
-			y: 7.5d
+			y: 5.500000000000005d
 		}
 		{
 			dependencies: ["681110DE6B4E6ED8"]
@@ -274,7 +274,7 @@
 				type: "item"
 			}]
 			x: 1.0d
-			y: 8.5d
+			y: 6.500000000000005d
 		}
 		{
 			description: ["Cleanroom Glass can be used for the walls in place of the Plascrete, just not the edges or floor"]
@@ -286,11 +286,10 @@
 				type: "item"
 			}]
 			x: 2.0d
-			y: 8.5d
+			y: 6.500000000000005d
 		}
 		{
 			dependencies: [
-				"3DCCEDC5A817EBEB"
 				"70C952B8FF3418F6"
 				"4FD6092D9C2A485C"
 			]
@@ -320,88 +319,7 @@
 				type: "item"
 			}]
 			x: -7.5d
-			y: -3.95d
-		}
-		{
-			dependencies: ["4E5FE40373675AED"]
-			description: [
-				"You can use a GT Assembler or a regular crafting grid to make this. Since pattern space is precious, especially for the GT Assembler, perhaps a Crafter or Molecular Assembler can handle putting it together"
-				""
-				"Swap out the LV Energy Hatches on your &eElectric Blast Furnace&r for these and your EBF can now process &6HV&r recipes! "
-				""
-				"Make sure you upgrade your power source too! "
-			]
-			id: "3DCCEDC5A817EBEB"
-			min_width: 250
-			rewards: [{
-				exclude_from_claim_all: true
-				id: "06054F7242DCA321"
-				table_id: 822291801189586703L
-				type: "loot"
-			}]
-			subtitle: "EBF Upgrades"
-			tasks: [{
-				count: 2L
-				id: "3E686316F9E6B29E"
-				item: "gtceu:mv_energy_input_hatch"
-				type: "item"
-			}]
-			x: -9.0d
-			y: -4.0d
-		}
-		{
-			dependencies: ["5B92DA55541B168B"]
-			description: ["Back into the &ecutter&r!"]
-			id: "4E5FE40373675AED"
-			rewards: [{
-				id: "27DFB41D8F75BF3B"
-				type: "xp"
-				xp: 250
-			}]
-			tasks: [{
-				id: "1C973641E5F60EB4"
-				item: "gtceu:ulpic_chip"
-				type: "item"
-			}]
-			x: -10.0d
-			y: -4.0d
-		}
-		{
-			dependencies: ["20A0A574F51EEF74"]
-			description: ["That's right, another &eLaser Engraver&r recipe..."]
-			id: "5B92DA55541B168B"
-			rewards: [{
-				count: 2
-				id: "0B4A34429F4F377A"
-				item: "gtceu:silicon_wafer"
-				random_bonus: 2
-				type: "item"
-			}]
-			tasks: [{
-				id: "0B0A35D87D18E3A1"
-				item: "gtceu:ulpic_wafer"
-				type: "item"
-			}]
-			x: -11.0d
-			y: -4.0d
-		}
-		{
-			description: [
-				"Follow the same steps in MV for the Emerald/Ruby lens to make the &9Sapphire Lens&r"
-				""
-				"{\"clickEvent\": {\"action\": \"change_page\", \"value\": \"4DD7F3508B757EF0\"}, \"text\": \"How to make the gem plate\", \"color\": \"green\", \"hoverEvent\": { \"action\":\"show_text\", \"contents\": { \"text\":\"Click here for a reminder\" } }}"
-				""
-				"{\"clickEvent\": {\"action\": \"change_page\", \"value\": \"26004F997C758011\"}, \"text\": \"How to make the gem lens\", \"color\": \"yellow\", \"hoverEvent\": { \"action\":\"show_text\", \"contents\": { \"text\":\"Click here for a reminder\" } }}"
-			]
-			id: "20A0A574F51EEF74"
-			shape: "square"
-			tasks: [{
-				id: "71285AC928BBD40E"
-				item: "gtceu:sapphire_lens"
-				type: "item"
-			}]
-			x: -11.0d
-			y: -3.0d
+			y: -1.9500000000000002d
 		}
 		{
 			dependencies: [
@@ -435,7 +353,7 @@
 				type: "item"
 			}]
 			x: 4.5d
-			y: -5.5d
+			y: -3.5d
 		}
 		{
 			dependencies: ["54BEC01D84237DBC"]
@@ -460,7 +378,7 @@
 				type: "item"
 			}]
 			x: 5.5d
-			y: -7.0d
+			y: -5.0d
 		}
 		{
 			description: [
@@ -485,7 +403,7 @@
 				type: "item"
 			}]
 			x: 9.0d
-			y: -1.0d
+			y: 1.0d
 		}
 		{
 			dependencies: ["12F24C9C6D2AF887"]
@@ -510,8 +428,8 @@
 				item: "gtceu:inductor"
 				type: "item"
 			}]
-			x: 8.0d
-			y: 1.0d
+			x: 7.5d
+			y: 2.8d
 		}
 		{
 			description: [
@@ -547,7 +465,7 @@
 			]
 			title: "CPU Chip"
 			x: 3.2d
-			y: -1.7999999999999998d
+			y: 0.20000000000000018d
 		}
 		{
 			dependencies: ["0B54990168F9B136"]
@@ -564,7 +482,7 @@
 				type: "item"
 			}]
 			x: 0.0d
-			y: -3.5d
+			y: -1.5d
 		}
 		{
 			dependencies: ["16154B77454631F4"]
@@ -589,7 +507,7 @@
 				type: "item"
 			}]
 			x: 0.0d
-			y: -4.5d
+			y: -2.5d
 		}
 		{
 			dependencies: ["62161044F3F3AB87"]
@@ -606,7 +524,7 @@
 				type: "item"
 			}]
 			x: 0.0d
-			y: -5.5d
+			y: -3.5d
 		}
 		{
 			dependencies: ["78DC12C2EB504E56"]
@@ -623,7 +541,7 @@
 				type: "item"
 			}]
 			x: 1.0d
-			y: -7.5d
+			y: -5.5d
 		}
 		{
 			description: [
@@ -650,7 +568,7 @@
 				type: "item"
 			}]
 			x: 1.0d
-			y: -8.5d
+			y: -6.5d
 		}
 		{
 			dependencies: ["503E5B82A6C89278"]
@@ -675,7 +593,7 @@
 				type: "item"
 			}]
 			x: 3.5d
-			y: -7.0d
+			y: -5.0d
 		}
 		{
 			dependencies: ["68526BA198AADD8E"]
@@ -698,7 +616,7 @@
 				type: "item"
 			}]
 			x: 11.5d
-			y: -1.5d
+			y: 0.5d
 		}
 		{
 			description: ["If you cannot find &belectrotine&r in the Nether, you can create it by mixing electrum and redstone in a &eMixer&r on &aProgram 1&r"]
@@ -716,7 +634,7 @@
 				type: "item"
 			}]
 			x: 11.5d
-			y: -3.0d
+			y: -1.0d
 		}
 		{
 			dependencies: ["6A243EDB2A99C76D"]
@@ -732,8 +650,8 @@
 				item: "gtceu:nickel_zinc_ferrite_ingot"
 				type: "item"
 			}]
-			x: 7.0d
-			y: 1.0d
+			x: 6.5d
+			y: 2.8d
 		}
 		{
 			description: [
@@ -753,8 +671,8 @@
 				item: "gtceu:ferrite_mixture_dust"
 				type: "item"
 			}]
-			x: 6.0d
-			y: 1.0d
+			x: 5.5d
+			y: 2.8d
 		}
 		{
 			dependencies: ["70C952B8FF3418F6"]
@@ -819,7 +737,7 @@
 				type: "item"
 			}]
 			x: -9.5d
-			y: 1.0d
+			y: 3.0d
 		}
 		{
 			description: [
@@ -851,7 +769,7 @@
 				type: "item"
 			}]
 			x: 1.0d
-			y: 6.5d
+			y: 4.500000000000005d
 		}
 		{
 			dependencies: ["0115271C840CD387"]
@@ -870,7 +788,7 @@
 				type: "item"
 			}]
 			x: -11.5d
-			y: -1.0d
+			y: 1.0d
 		}
 		{
 			dependencies: ["70C952B8FF3418F6"]
@@ -900,7 +818,7 @@
 				type: "item"
 			}]
 			x: -9.5d
-			y: -1.0d
+			y: 1.0d
 		}
 		{
 			description: [
@@ -953,7 +871,7 @@
 				}
 			]
 			x: -1.0d
-			y: -7.5d
+			y: -5.5d
 		}
 		{
 			dependencies: ["1957A39483E15508"]
@@ -974,7 +892,7 @@
 				type: "item"
 			}]
 			x: 3.5d
-			y: -8.0d
+			y: -6.0d
 		}
 		{
 			dependencies: ["6A2D7380E340B77D"]
@@ -995,7 +913,7 @@
 				type: "item"
 			}]
 			x: 3.5d
-			y: -9.0d
+			y: -7.0d
 		}
 		{
 			description: [
@@ -1019,7 +937,7 @@
 				type: "item"
 			}]
 			x: 5.0d
-			y: -9.0d
+			y: -7.0d
 		}
 		{
 			dependencies: [
@@ -1041,7 +959,7 @@
 				type: "item"
 			}]
 			x: 0.0d
-			y: -6.5d
+			y: -4.5d
 		}
 		{
 			dependencies: [
@@ -1061,7 +979,7 @@
 				type: "item"
 			}]
 			x: 5.5d
-			y: -8.0d
+			y: -6.0d
 		}
 		{
 			description: [
@@ -1084,7 +1002,7 @@
 				type: "item"
 			}]
 			x: 6.0d
-			y: -9.0d
+			y: -7.0d
 		}
 		{
 			description: [
@@ -1100,7 +1018,7 @@
 				type: "item"
 			}]
 			x: 0.0d
-			y: 8.5d
+			y: 6.500000000000005d
 		}
 		{
 			description: [
@@ -1136,7 +1054,7 @@
 				type: "item"
 			}]
 			x: -7.5d
-			y: -5.5d
+			y: -3.5d
 		}
 		{
 			dependencies: [
@@ -1165,7 +1083,7 @@
 				type: "item"
 			}]
 			x: -7.5d
-			y: 3.5d
+			y: 5.5d
 		}
 		{
 			dependencies: ["70C952B8FF3418F6"]
@@ -1195,7 +1113,7 @@
 				type: "item"
 			}]
 			x: -6.5d
-			y: 2.5d
+			y: 4.5d
 		}
 		{
 			dependencies: ["70C952B8FF3418F6"]
@@ -1228,12 +1146,12 @@
 				}
 			]
 			x: -8.5d
-			y: 2.5d
+			y: 4.5d
 		}
 		{
 			dependencies: ["70C952B8FF3418F6"]
 			description: [
-				"Finally, at &6HV&r you get access to the &dByproducts&r"
+				"Finally, at &6HV&r you get access to the &dByproducts&r from the &eMacerator&r"
 				""
 				"These byproducts are often incredibly useful and will come in handy multiple times as you progress"
 			]
@@ -1266,7 +1184,7 @@
 			]
 			title: "Ore Processing Upgrade"
 			x: -7.5d
-			y: 2.5d
+			y: 4.5d
 		}
 	]
 	title: "{atm9.chapters.29.title}"

--- a/config/ftbquests/quests/chapters/insane_voltage.snbt
+++ b/config/ftbquests/quests/chapters/insane_voltage.snbt
@@ -207,6 +207,7 @@
 			dependencies: [
 				"533DB1666B11489A"
 				"12905D5778274DEE"
+				"1FF8B0E2D10C88E9"
 			]
 			description: ["With 16 of these on your &eElectric Blast Furnace&r you can cook recipes up to &c4500 Kelvin&r! That's 4227 Celsius or 7640 Fahrenheit!"]
 			id: "0A848E0B9F485B2C"
@@ -214,16 +215,29 @@
 				{
 					count: 6
 					id: "393AD63D08C4587C"
-					item: "gtceu:vanadium_dust"
+					item: "gtceu:molybdenum_dust"
 					random_bonus: 6
 					type: "item"
 				}
 				{
 					count: 8
 					id: "2561A6499CDB6E06"
-					item: "gtceu:tungsten_steel_dust"
+					item: "gtceu:ruthenium_dust"
 					random_bonus: 8
 					type: "item"
+				}
+				{
+					count: 8
+					id: "0BE7E36683619E3D"
+					item: "gtceu:chromium_dust"
+					random_bonus: 8
+					type: "item"
+				}
+				{
+					exclude_from_claim_all: true
+					id: "2212F4C424085656"
+					table_id: 6202000790833671070L
+					type: "loot"
 				}
 			]
 			tasks: [{
@@ -231,8 +245,8 @@
 				item: "gtceu:rtm_alloy_coil_block"
 				type: "item"
 			}]
-			x: -4.800000000000001d
-			y: 0.7999999999999998d
+			x: -2.5d
+			y: 0.7999999999999999d
 		}
 		{
 			dependencies: [
@@ -717,7 +731,7 @@
 				item: "gtceu:ev_assembler"
 				type: "item"
 			}]
-			x: -4.800000000000001d
+			x: -2.5d
 			y: 2.0d
 		}
 		{
@@ -1813,8 +1827,8 @@
 				item: "gtceu:vanadium_gallium_dust"
 				type: "item"
 			}]
-			x: -4.800000000000001d
-			y: -1.1999999999999993d
+			x: -7.0d
+			y: -4.0d
 		}
 		{
 			dependencies: ["5F270891C953486E"]
@@ -1900,8 +1914,8 @@
 				item: "gtceu:vanadium_gallium_ingot"
 				type: "item"
 			}]
-			x: -3.3999999999999995d
-			y: -0.19999999999999973d
+			x: -2.5d
+			y: -4.0d
 		}
 		{
 			dependencies: [
@@ -2268,6 +2282,245 @@
 			}]
 			x: 4.0d
 			y: -3.5d
+		}
+		{
+			dependencies: ["64F77D41B2D057B8"]
+			description: ["While not necessary, the IV Macerator will give you a speed boost on processing Sheldonite, as this processing line can be quite &n&l&2TimeConsuming.&r&r&r"]
+			hide_dependency_lines: true
+			id: "16B44F78707E148E"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "7771EA6688348CD0"
+				table_id: 6202000790833671070L
+				type: "loot"
+			}]
+			shape: "diamond"
+			size: 1.5d
+			subtitle: "Hey, Macerator, Yaaah!"
+			tasks: [{
+				id: "783804D20825EC31"
+				item: "gtceu:iv_macerator"
+				type: "item"
+			}]
+			x: -6.0d
+			y: -3.1d
+		}
+		{
+			dependencies: ["16B44F78707E148E"]
+			description: ["Processing Sheldonite and purifying it will allow you to get the highest return on Platinum Group Sludge. This Sludge contains resources you need to progress."]
+			id: "2FDACD6F153D5B64"
+			rewards: [{
+				count: 16
+				id: "02F35F6C06C59F87"
+				item: "gtceu:raw_cooperite"
+				random_bonus: 32
+				type: "item"
+			}]
+			subtitle: "My Friend Sheldon went to a club on nite."
+			tasks: [{
+				id: "3E85E016A9FC831F"
+				item: "gtceu:raw_cooperite"
+				type: "item"
+			}]
+			x: -4.5d
+			y: -3.1d
+		}
+		{
+			dependencies: ["2FDACD6F153D5B64"]
+			description: ["&l&6Aqua Regia&r&r is a mixture of Concentrated Nitric Acid and Hydrochloric Acid, usually one part to three parts, respectively. The Mixture was given its name (literally \"Royal Water\") by alchemists because of its ability to dissovle &l&eGold&r&r."]
+			id: "0DD389A24F5F8CDD"
+			rewards: [{
+				id: "2BD13756A8D0E6D0"
+				item: {
+					Count: 1b
+					ForgeCaps: {
+						Parent: {
+							Amount: 16000
+							FluidName: "gtceu:aqua_regia"
+							capacity: 16000
+						}
+					}
+					id: "evilcraft:dark_tank"
+					tag: {
+						Fluid: {
+							Amount: 16000
+							FluidName: "gtceu:aqua_regia"
+						}
+						capacity: 16000
+					}
+				}
+				type: "item"
+			}]
+			subtitle: "Im a Barbie Girl, In a Barbie world... If you know, you know."
+			tasks: [{
+				id: "167A231788D5F833"
+				item: "gtceu:aqua_regia_bucket"
+				type: "item"
+			}]
+			x: -4.0d
+			y: -2.0500000000000007d
+		}
+		{
+			dependencies: ["2FDACD6F153D5B64"]
+			description: ["Platinum Group Sludge will process down into a bunch of great resources that will help you moving forward."]
+			id: "4632DA3CE9D95064"
+			rewards: [{
+				count: 8
+				id: "029845A689A9ED7D"
+				item: "gtceu:platinum_group_sludge_dust"
+				random_bonus: 16
+				type: "item"
+			}]
+			subtitle: "Money! *Mister Krabs*"
+			tasks: [{
+				id: "6D5FD9D06E3AD241"
+				item: "gtceu:platinum_group_sludge_dust"
+				type: "item"
+			}]
+			x: -5.0d
+			y: -2.0500000000000007d
+		}
+		{
+			dependencies: [
+				"4632DA3CE9D95064"
+				"20A01B6A6B1177CB"
+				"0DD389A24F5F8CDD"
+			]
+			description: [
+				"This wont be inert for long! Once processed you will have a BUNCH of new resources in hand, which can be further processed into very useful materials!"
+				""
+				"Make sure to get a passive processing line of this going, as you will need quite a bit of the resulting resources."
+			]
+			id: "7CC3BD5F3D66A637"
+			rewards: [{
+				count: 6
+				id: "1B047E534CB265CB"
+				item: "gtceu:inert_metal_mixture_dust"
+				random_bonus: 6
+				type: "item"
+			}]
+			subtitle: "A cloud of radon floats into a cafe. The waiter says, \"we don't serve inert gases here\". There was no reaction from the radon."
+			tasks: [{
+				id: "2F0E1D0E62D27DF0"
+				item: "gtceu:inert_metal_mixture_dust"
+				type: "item"
+			}]
+			x: -4.5d
+			y: -1.0500000000000007d
+		}
+		{
+			dependencies: ["64F77D41B2D057B8"]
+			description: [
+				"Another tier up, another boost to processing time. But again, theres no time to get comfortable. The new resources we will be processing will need further advancements to bring those processing times down. So keep at it!"
+				""
+				"You are doing great!!"
+			]
+			hide_dependency_lines: true
+			id: "20A01B6A6B1177CB"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "1BBA9D4D6693F074"
+				table_id: 6202000790833671070L
+				type: "loot"
+			}]
+			subtitle: "You Spin me Right Round... Oh Come on, you knew it was coming..."
+			tasks: [{
+				id: "7609E81C3C3C8F78"
+				item: "gtceu:iv_centrifuge"
+				type: "item"
+			}]
+			x: -5.5d
+			y: -1.0d
+		}
+		{
+			dependencies: ["7CC3BD5F3D66A637"]
+			description: ["Now that we have broken down the Inert Metal mixure, we have 2 new resources, both of which are extremely valuable to us in the &dLuv&r Tier! Make sure to get a passive line going so we have a constant supply of these resources flowing in!"]
+			id: "439556C571592D81"
+			rewards: [
+				{
+					id: "36D580AD734CBBA6"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							Parent: {
+								Amount: 16000
+								FluidName: "gtceu:rhodium_sulfate"
+								capacity: 16000
+							}
+						}
+						id: "evilcraft:dark_tank"
+						tag: {
+							Fluid: {
+								Amount: 16000
+								FluidName: "gtceu:rhodium_sulfate"
+							}
+							capacity: 16000
+						}
+					}
+					type: "item"
+				}
+				{
+					count: 6
+					id: "775ACF8F8D043BB8"
+					item: "gtceu:ruthenium_tetroxide_dust"
+					random_bonus: 6
+					type: "item"
+				}
+			]
+			shape: "gear"
+			subtitle: "2 for 1! What a deal!"
+			tasks: [
+				{
+					id: "195C8E82DDC275B1"
+					item: "gtceu:ruthenium_tetroxide_dust"
+					type: "item"
+				}
+				{
+					id: "18C94C4E8484B27A"
+					item: "gtceu:rhodium_sulfate_bucket"
+					type: "item"
+				}
+			]
+			x: -3.5d
+			y: -1.0500000000000007d
+		}
+		{
+			dependencies: ["439556C571592D81"]
+			description: ["Now that we have pure Ruthenium, we can make it dirty again! Haha! Use a mixer to turn this into Ruridit. We will need quite a bit of Ruridit for other processes and items, including the Assembly Line!"]
+			id: "40249CD28957E7EB"
+			rewards: [{
+				count: 6
+				id: "09A68E6B45224827"
+				item: "gtceu:ruthenium_dust"
+				random_bonus: 6
+				type: "item"
+			}]
+			subtitle: "Cleaned up the Dust"
+			tasks: [{
+				id: "270A0E25457E1C36"
+				item: "gtceu:ruthenium_dust"
+				type: "item"
+			}]
+			x: -4.5d
+			y: 0.0d
+		}
+		{
+			dependencies: ["40249CD28957E7EB"]
+			id: "1FF8B0E2D10C88E9"
+			rewards: [{
+				count: 6
+				id: "3FB909CCA3040943"
+				item: "gtceu:ruthenium_dust"
+				random_bonus: 6
+				type: "item"
+			}]
+			tasks: [{
+				id: "0020D722D78214B3"
+				item: "gtceu:rtm_alloy_dust"
+				type: "item"
+			}]
+			x: -3.5d
+			y: 0.0d
 		}
 	]
 	title: "{atm9.chapters.31.title}"

--- a/config/ftbquests/quests/chapters/insane_voltage.snbt
+++ b/config/ftbquests/quests/chapters/insane_voltage.snbt
@@ -377,13 +377,21 @@
 			]
 			description: ["Don't forget, once you've made these you can update those old circuit recipes that used regular Transistors to use the Advanced Transistor"]
 			id: "1809493D8765E67A"
-			rewards: [{
-				count: 4
-				id: "092E25B584C9B2A5"
-				item: "gtceu:hssg_dust"
-				random_bonus: 4
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 4
+					id: "092E25B584C9B2A5"
+					item: "gtceu:hssg_dust"
+					random_bonus: 4
+					type: "item"
+				}
+				{
+					exclude_from_claim_all: true
+					id: "4C5E99E3A5CF135D"
+					table_id: 6202000790833671070L
+					type: "loot"
+				}
+			]
 			tasks: [{
 				id: "4AD1E09D72AD01E3"
 				item: "gtceu:advanced_smd_transistor"
@@ -403,13 +411,21 @@
 				"Is this really a boost? Yes! Mainly because you use fewer of the Advanced SMD Resistors, but also because the regular kind won't be usable forever..."
 			]
 			id: "2CC2E23077A0509F"
-			rewards: [{
-				count: 4
-				id: "1559A17E6BEF564D"
-				item: "gtceu:graphene_dust"
-				random_bonus: 4
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 4
+					id: "1559A17E6BEF564D"
+					item: "gtceu:graphene_dust"
+					random_bonus: 4
+					type: "item"
+				}
+				{
+					exclude_from_claim_all: true
+					id: "754E11897AC4D998"
+					table_id: 6202000790833671070L
+					type: "loot"
+				}
+			]
 			tasks: [{
 				id: "3667F2D12BD686DD"
 				item: "gtceu:advanced_smd_resistor"
@@ -420,9 +436,10 @@
 		}
 		{
 			dependencies: [
-				"599BABC83E76A711"
 				"1D9194E89D14BA85"
 				"45D9E32D75F5ACAE"
+				"599BABC83E76A711"
+				"1AB86FD8776634D0"
 			]
 			description: [
 				"Finally, this unlocks the HV circuit at the Nanoprocessor tier!"
@@ -430,13 +447,21 @@
 				"Well, technically you could've made it without using the Advanced SMD components, but where's the fun in that?"
 			]
 			id: "239E32216382AA5D"
-			rewards: [{
-				count: 4
-				id: "261F7E2E3450A321"
-				item: "gtceu:hsss_dust"
-				random_bonus: 4
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 6
+					id: "261F7E2E3450A321"
+					item: "gtceu:hsss_dust"
+					random_bonus: 6
+					type: "item"
+				}
+				{
+					exclude_from_claim_all: true
+					id: "24F7EAB4EA5990C0"
+					table_id: 6202000790833671070L
+					type: "loot"
+				}
+			]
 			tasks: [{
 				id: "38023F3A53A1FFF3"
 				item: "gtceu:advanced_smd_capacitor"
@@ -458,13 +483,21 @@
 				"Be sure going forward that you make recipes using the Advanced SMD Components because they are cheaper"
 			]
 			id: "1A73520CB284217F"
-			rewards: [{
-				count: 4
-				id: "4A67FAA8B49E8FDF"
-				item: "gtceu:niobium_titanium_dust"
-				random_bonus: 4
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 4
+					id: "4A67FAA8B49E8FDF"
+					item: "gtceu:niobium_titanium_dust"
+					random_bonus: 4
+					type: "item"
+				}
+				{
+					exclude_from_claim_all: true
+					id: "15067CF3E3F6062F"
+					table_id: 6202000790833671070L
+					type: "loot"
+				}
+			]
 			tasks: [{
 				id: "6971A717F3A6343E"
 				item: "gtceu:advanced_smd_diode"
@@ -479,16 +512,25 @@
 				"4720F9EDF894330C"
 				"1D9194E89D14BA85"
 				"45D9E32D75F5ACAE"
+				"1AB86FD8776634D0"
 			]
 			description: ["The Advanced Inductor! Keep updating those old recipes"]
 			id: "574019B5B7CA43E0"
-			rewards: [{
-				count: 8
-				id: "26CA1388FAD74DE1"
-				item: "gtceu:palladium_dust"
-				random_bonus: 8
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 8
+					id: "26CA1388FAD74DE1"
+					item: "gtceu:palladium_dust"
+					random_bonus: 8
+					type: "item"
+				}
+				{
+					exclude_from_claim_all: true
+					id: "377F61DFB3FDCCD7"
+					table_id: 6202000790833671070L
+					type: "loot"
+				}
+			]
 			tasks: [{
 				id: "227F895573C8DCA9"
 				item: "gtceu:advanced_smd_inductor"
@@ -735,27 +777,41 @@
 			y: 2.0d
 		}
 		{
-			dependencies: ["41EE8B40BA43DADE"]
+			dependencies: [
+				"41EE8B40BA43DADE"
+				"4632DA3CE9D95064"
+				"47871110028991D3"
+			]
 			description: [
 				"You'll smelt this and flatten it into &bFoils&r to make the delicate layers that comprise the &dAdvanced SMD Capacitor&r"
 				""
-				"If you're having a hard time finding &aIridium&r, you can get a head start on the &ePlatLine™&r which won't be covered until the next chapter because this one is already quite full"
+				"If you're having a hard time finding &aIridium Ore&r, then you can work towards the &5Iridium Bee&r, or start on processing the &eRarest Metal Mixture&r from the &6PlatLine™&r"
 			]
+			hide_dependency_lines: true
 			id: "599BABC83E76A711"
-			rewards: [{
-				count: 6
-				id: "138DF43E45BCBD66"
-				item: "alltheores:iridium_dust"
-				random_bonus: 6
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 16
+					id: "138DF43E45BCBD66"
+					item: "alltheores:raw_iridium"
+					random_bonus: 16
+					type: "item"
+				}
+				{
+					count: 12
+					id: "5C2C7A388507B5C3"
+					item: "gtceu:hsss_dust"
+					random_bonus: 12
+					type: "item"
+				}
+			]
 			tasks: [{
 				id: "04CE037EB56DFF14"
 				item: "gtceu:hsss_dust"
 				type: "item"
 			}]
-			x: 7.0d
-			y: -3.0d
+			x: 6.199999999999999d
+			y: -2.8999999999999995d
 		}
 		{
 			dependencies: ["6517B8748E3A6831"]
@@ -900,10 +956,10 @@
 			]
 			id: "4720F9EDF894330C"
 			rewards: [{
-				count: 6
+				count: 12
 				id: "51FF1B9CA03B0275"
 				item: "gtceu:hsse_dust"
-				random_bonus: 6
+				random_bonus: 12
 				type: "item"
 			}]
 			tasks: [{
@@ -2521,6 +2577,49 @@
 			}]
 			x: -3.5d
 			y: 0.0d
+		}
+		{
+			dependencies: [
+				"41EE8B40BA43DADE"
+				"45D9E32D75F5ACAE"
+			]
+			description: [
+				"That's right, two &eEBF&r coil upgrades in one chapter! "
+				""
+				"You'll have to make these coils to smelt the High Speed Steel S and E variants for the Advanced SMD Components"
+				""
+				"&l&eNote:&r&r Making the Advanced SMD Components is not strictly necessary to make the Nanoprocessors"
+			]
+			id: "1AB86FD8776634D0"
+			rewards: [
+				{
+					count: 16
+					id: "0FCE644F73F35583"
+					item: "gtceu:tungsten_dust"
+					random_bonus: 16
+					type: "item"
+				}
+				{
+					count: 16
+					id: "1DC9FB0667F710A0"
+					item: "gtceu:hssg_dust"
+					random_bonus: 16
+					type: "item"
+				}
+				{
+					exclude_from_claim_all: true
+					id: "47CD64F1B76FEC3C"
+					table_id: 6202000790833671070L
+					type: "loot"
+				}
+			]
+			tasks: [{
+				id: "231B87784B7EC352"
+				item: "gtceu:hssg_coil_block"
+				type: "item"
+			}]
+			x: 7.0d
+			y: -3.4999999999999996d
 		}
 	]
 	title: "{atm9.chapters.31.title}"

--- a/config/ftbquests/quests/chapters/insane_voltage.snbt
+++ b/config/ftbquests/quests/chapters/insane_voltage.snbt
@@ -777,17 +777,14 @@
 			y: 2.0d
 		}
 		{
-			dependencies: [
-				"41EE8B40BA43DADE"
-				"4632DA3CE9D95064"
-				"47871110028991D3"
-			]
+			dependencies: ["41EE8B40BA43DADE"]
 			description: [
 				"You'll smelt this and flatten it into &bFoils&r to make the delicate layers that comprise the &dAdvanced SMD Capacitor&r"
 				""
 				"If you're having a hard time finding &aIridium Ore&r, then you can work towards the &5Iridium Bee&r, or start on processing the &eRarest Metal Mixture&r from the &6PlatLine™&r"
+				""
+				"{\"clickEvent\": {\"action\": \"change_page\", \"value\": \"2EE52FD7129D3D87\"}, \"text\": \"How to: Rarest Metal Mixture\", \"color\": \"yellow\", \"hoverEvent\": { \"action\":\"show_text\", \"contents\": { \"text\":\"Click here to open the quest!\" } }}"
 			]
-			hide_dependency_lines: true
 			id: "599BABC83E76A711"
 			rewards: [
 				{
@@ -1036,7 +1033,7 @@
 				type: "item"
 			}]
 			x: 3.0d
-			y: -5.200000000000001d
+			y: -6.199999999999999d
 		}
 		{
 			dependencies: ["43EBA1D735267C85"]
@@ -2620,6 +2617,114 @@
 			}]
 			x: 7.0d
 			y: -3.4999999999999996d
+		}
+		{
+			dependencies: ["4632DA3CE9D95064"]
+			description: [
+				"Iridium Ore is truly quite rare, so I wouldn't be surprised if you have not found any"
+				""
+				"As such, we can work on more of the &6PlatLine™&r to acquire Iridium"
+			]
+			hide_dependency_lines: true
+			id: "2EE52FD7129D3D87"
+			optional: true
+			rewards: [{
+				count: 8
+				id: "2BB47D5128FF5D50"
+				item: "gtceu:rarest_metal_mixture_dust"
+				random_bonus: 16
+				type: "item"
+			}]
+			shape: "diamond"
+			tasks: [{
+				id: "2AF36DE65F7CBA3C"
+				item: "gtceu:rarest_metal_mixture_dust"
+				type: "item"
+			}]
+			x: 3.5d
+			y: -2.5d
+		}
+		{
+			dependencies: [
+				"2EE52FD7129D3D87"
+				"47871110028991D3"
+			]
+			description: [
+				"Only the &eLarge Chemical Reactor&r can handle this reaction!"
+				""
+				"We won't use the Acidic Osmium Solution because Osmium is plentiful"
+			]
+			id: "7C9D8120B5C5BD9B"
+			optional: true
+			rewards: [{
+				count: 8
+				id: "3B3D8C01C31D63D8"
+				item: "gtceu:iridium_metal_residue_dust"
+				random_bonus: 16
+				type: "item"
+			}]
+			shape: "diamond"
+			tasks: [{
+				id: "35F58171ECC99A6A"
+				item: "gtceu:iridium_metal_residue_dust"
+				type: "item"
+			}]
+			x: 3.0d
+			y: -3.0d
+		}
+		{
+			dependencies: ["7C9D8120B5C5BD9B"]
+			description: [
+				"This step is easy, we just &eCentrifuge&r our Residue and we're left with Iridium Chloride and some sludge"
+				""
+				"You can further process that sludge if you want to, but it isn't necessary to get the coveted Iridium"
+			]
+			id: "6E6D9527AC093199"
+			optional: true
+			rewards: [{
+				count: 8
+				id: "04637191A807D0C9"
+				item: "gtceu:iridium_chloride_dust"
+				random_bonus: 16
+				type: "item"
+			}]
+			shape: "diamond"
+			tasks: [{
+				id: "4671D5F7C6163DF9"
+				item: "gtceu:iridium_chloride_dust"
+				type: "item"
+			}]
+			x: 3.0d
+			y: -4.0d
+		}
+		{
+			dependencies: ["6E6D9527AC093199"]
+			description: ["All that is left to do is use a &eChemical Reaction&r to pull the Chlorine off the Iridium!"]
+			id: "02190383FEE793ED"
+			optional: true
+			rewards: [
+				{
+					count: 8
+					id: "73F219D4D8F72B5A"
+					item: "alltheores:iridium_dust"
+					random_bonus: 16
+					type: "item"
+				}
+				{
+					exclude_from_claim_all: true
+					id: "35A9005AF56D5554"
+					table_id: 6202000790833671070L
+					type: "loot"
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "074663BA515D70DF"
+				item: "alltheores:iridium_dust"
+				type: "item"
+			}]
+			x: 3.5d
+			y: -4.5d
 		}
 	]
 	title: "{atm9.chapters.31.title}"

--- a/config/ftbquests/quests/chapters/ludicrous_voltage.snbt
+++ b/config/ftbquests/quests/chapters/ludicrous_voltage.snbt
@@ -987,7 +987,7 @@
 					id: "29711CF4D4E5241C"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_wire_factory"
+					to_observe: "gtceu:large_wiremill"
 					type: "observation"
 				}
 			]
@@ -1031,7 +1031,7 @@
 					id: "578BB941AE6A7856"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_solidification_array"
+					to_observe: "gtceu:large_solidifier"
 					type: "observation"
 				}
 			]
@@ -1081,7 +1081,7 @@
 					id: "65FE174D4A5F484C"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_extrusion_machine"
+					to_observe: "gtceu:large_extruder"
 					type: "observation"
 				}
 			]
@@ -1126,7 +1126,7 @@
 					observe_type: 2
 					timer: 0L
 					title: "Observe Complete Large Extraction Machine"
-					to_observe: "gtceu:large_extraction_machine"
+					to_observe: "gtceu:large_extractor"
 					type: "observation"
 				}
 			]
@@ -1173,7 +1173,7 @@
 					id: "3787DE68318D9E46"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_fractioning_distillery"
+					to_observe: "gtceu:large_distillery"
 					type: "observation"
 				}
 			]
@@ -1223,7 +1223,7 @@
 					id: "034EAE3D86F06F1C"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_cutting_saw"
+					to_observe: "gtceu:large_cutter"
 					type: "observation"
 				}
 			]
@@ -1365,7 +1365,7 @@
 					id: "553C54B8B3A652D0"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_crystallization_chamber"
+					to_observe: "gtceu:large_autoclave"
 					type: "observation"
 				}
 			]
@@ -1571,7 +1571,7 @@
 					id: "51A72B7982E04028"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_circuit_assembling_facility"
+					to_observe: "gtceu:large_circuit_assembler"
 					type: "observation"
 				}
 			]
@@ -1619,7 +1619,7 @@
 					id: "763B8BD528C50FF3"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_assembling_factory"
+					to_observe: "gtceu:large_assembler"
 					type: "observation"
 				}
 			]
@@ -1715,7 +1715,7 @@
 					id: "7FC8BBB169091341"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_electrolysis_chamber"
+					to_observe: "gtceu:large_electrolyzer"
 					type: "observation"
 				}
 			]
@@ -1771,7 +1771,7 @@
 					id: "1E34B345EFB46198"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_mixing_vessel"
+					to_observe: "gtceu:large_mixer"
 					type: "observation"
 				}
 			]
@@ -1815,7 +1815,7 @@
 					id: "040583DD9EFA80F1"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:large_centrifugal_unit"
+					to_observe: "gtceu:large_centrifuge"
 					type: "observation"
 				}
 			]

--- a/config/ftbquests/quests/chapters/ludicrous_voltage.snbt
+++ b/config/ftbquests/quests/chapters/ludicrous_voltage.snbt
@@ -130,167 +130,7 @@
 			y: 1.5d
 		}
 		{
-			dependencies: ["2FDACD6F153D5B64"]
-			description: ["&l&6Aqua Regia&r&r is a mixture of Concentrated Nitric Acid and Hydrochloric Acid, usually one part to three parts, respectively. The Mixture was given its name (literally \"Royal Water\") by alchemists because of its ability to dissovle &l&eGold&r&r."]
-			id: "0DD389A24F5F8CDD"
-			rewards: [{
-				id: "2BD13756A8D0E6D0"
-				item: {
-					Count: 1b
-					ForgeCaps: {
-						Parent: {
-							Amount: 16000
-							FluidName: "gtceu:aqua_regia"
-							capacity: 16000
-						}
-					}
-					id: "evilcraft:dark_tank"
-					tag: {
-						Fluid: {
-							Amount: 16000
-							FluidName: "gtceu:aqua_regia"
-						}
-						capacity: 16000
-					}
-				}
-				type: "item"
-			}]
-			subtitle: "Im a Barbie Girl, In a Barbie world... If you know, you know."
-			tasks: [{
-				id: "167A231788D5F833"
-				item: "gtceu:aqua_regia_bucket"
-				type: "item"
-			}]
-			x: -8.0d
-			y: -2.0d
-		}
-		{
-			dependencies: ["2FDACD6F153D5B64"]
-			description: ["Platinum Group Sludge will process down into a bunch of great resources that will help you moving forward."]
-			id: "4632DA3CE9D95064"
-			rewards: [{
-				count: 8
-				id: "029845A689A9ED7D"
-				item: "gtceu:platinum_group_sludge_dust"
-				random_bonus: 16
-				type: "item"
-			}]
-			subtitle: "Money! *Mister Krabs*"
-			tasks: [{
-				id: "6D5FD9D06E3AD241"
-				item: "gtceu:platinum_group_sludge_dust"
-				type: "item"
-			}]
-			x: -7.0d
-			y: -2.0d
-		}
-		{
-			dependencies: [
-				"4632DA3CE9D95064"
-				"20A01B6A6B1177CB"
-				"0DD389A24F5F8CDD"
-			]
-			description: [
-				"This wont be inert for long! Once processed you will have a BUNCH of new resources in hand, which can be further processed into very useful materials!"
-				""
-				"Make sure to get a passive processing line of this going, as you will need quite a bit of the resulting resources."
-			]
-			id: "7CC3BD5F3D66A637"
-			rewards: [{
-				count: 6
-				id: "1B047E534CB265CB"
-				item: "gtceu:inert_metal_mixture_dust"
-				random_bonus: 6
-				type: "item"
-			}]
-			subtitle: "A cloud of radon floats into a cafe. The waiter says, \"we don't serve inert gases here\". There was no reaction from the radon."
-			tasks: [{
-				id: "2F0E1D0E62D27DF0"
-				item: "gtceu:inert_metal_mixture_dust"
-				type: "item"
-			}]
-			x: -7.5d
-			y: -3.0d
-		}
-		{
-			description: [
-				"Another tier up, another boost to processing time. But again, theres no time to get comfortable. The new resources we will be processing will need further advancements to bring those processing times down. So keep at it!"
-				""
-				"You are doing great!!"
-			]
-			id: "20A01B6A6B1177CB"
-			rewards: [{
-				exclude_from_claim_all: true
-				id: "217A286DEB4D851D"
-				table_id: 7041264405549027492L
-				type: "loot"
-			}]
-			subtitle: "You Spin me Right Round... Oh Come on, you knew it was coming..."
-			tasks: [{
-				id: "7609E81C3C3C8F78"
-				item: "gtceu:iv_centrifuge"
-				type: "item"
-			}]
-			x: -8.5d
-			y: -3.0d
-		}
-		{
-			dependencies: ["7CC3BD5F3D66A637"]
-			description: ["Now that we have broken down the Inert Metal mixure, we have 2 new resources, both of which are extremely valuable to us in the &dLuv&r Tier! Make sure to get a passive line going so we have a constant supply of these resources flowing in!"]
-			id: "439556C571592D81"
-			rewards: [
-				{
-					id: "36D580AD734CBBA6"
-					item: {
-						Count: 1b
-						ForgeCaps: {
-							Parent: {
-								Amount: 16000
-								FluidName: "gtceu:rhodium_sulfate"
-								capacity: 16000
-							}
-						}
-						id: "evilcraft:dark_tank"
-						tag: {
-							Fluid: {
-								Amount: 16000
-								FluidName: "gtceu:rhodium_sulfate"
-							}
-							capacity: 16000
-						}
-					}
-					type: "item"
-				}
-				{
-					count: 6
-					id: "775ACF8F8D043BB8"
-					item: "gtceu:ruthenium_tetroxide_dust"
-					random_bonus: 6
-					type: "item"
-				}
-			]
-			shape: "gear"
-			subtitle: "2 for 1! What a deal!"
-			tasks: [
-				{
-					id: "195C8E82DDC275B1"
-					item: "gtceu:ruthenium_tetroxide_dust"
-					type: "item"
-				}
-				{
-					id: "18C94C4E8484B27A"
-					item: "gtceu:rhodium_sulfate_bucket"
-					type: "item"
-				}
-			]
-			x: -5.5d
-			y: -3.0d
-		}
-		{
-			dependencies: [
-				"439556C571592D81"
-				"3B1268D75B34A0F6"
-			]
+			dependencies: ["3B1268D75B34A0F6"]
 			description: ["Now that we have Rhodium, we can mix it with Palladium to get Rhodium plated Palladium, and process those into ingots, then plates, and then we can make &dLuV&r tier Hulls, meaning &dLuV&r Tier machines!!"]
 			id: "639B1F99D7271C07"
 			rewards: [{
@@ -310,6 +150,7 @@
 			y: -1.7999999999999998d
 		}
 		{
+			dependencies: ["5A658F239928850E"]
 			description: [
 				"Now were talking! Our machines have some Horsepower behind them. However, even if it seems ridiculous, we are going to need more!"
 				""
@@ -328,7 +169,7 @@
 				item: "gtceu:iv_electrolyzer"
 				type: "item"
 			}]
-			x: -4.5d
+			x: -7.0d
 			y: -1.7999999999999998d
 		}
 		{
@@ -455,46 +296,6 @@
 			}]
 			x: 7.599999999999994d
 			y: 1.5d
-		}
-		{
-			dependencies: ["16B44F78707E148E"]
-			description: ["Processing Sheldonite and purifying it will allow you to get the highest return on Platinum Group Sludge. This Sludge contains resources you need to progress."]
-			id: "2FDACD6F153D5B64"
-			rewards: [{
-				count: 16
-				id: "02F35F6C06C59F87"
-				item: "gtceu:raw_cooperite"
-				random_bonus: 32
-				type: "item"
-			}]
-			subtitle: "My Friend Sheldon went to a club on nite."
-			tasks: [{
-				id: "3E85E016A9FC831F"
-				item: "gtceu:raw_cooperite"
-				type: "item"
-			}]
-			x: -7.5d
-			y: -1.0d
-		}
-		{
-			description: ["While not necessary, the IV Macerator will give you a speed boost on processing Sheldonite, as this processing line can be quite &n&l&2TimeConsuming.&r&r&r"]
-			id: "16B44F78707E148E"
-			rewards: [{
-				exclude_from_claim_all: true
-				id: "3E7B794FA4D3FC19"
-				table_id: 7041264405549027492L
-				type: "loot"
-			}]
-			shape: "diamond"
-			size: 1.5d
-			subtitle: "Hey, Macerator, Yaaah!"
-			tasks: [{
-				id: "783804D20825EC31"
-				item: "gtceu:iv_macerator"
-				type: "item"
-			}]
-			x: -9.5d
-			y: -0.9500000000000002d
 		}
 		{
 			description: ["We need to mix up some HSLA to make Plates for the Alloy Blast Smelter's walls."]
@@ -645,7 +446,7 @@
 			y: 4.0d
 		}
 		{
-			dependencies: ["40249CD28957E7EB"]
+			dependencies: ["033BF8D12E32A5E5"]
 			description: ["Youll need quite a bit of Ruridit. Passive your lines to keep a steady supply."]
 			id: "1DBF5A76DCDF5E49"
 			rewards: [{
@@ -2416,26 +2217,6 @@
 			y: 1.5d
 		}
 		{
-			dependencies: ["439556C571592D81"]
-			description: ["Now that we have pure Ruthenium, we can make it dirty again! Haha! Use a mixer to turn this into Ruridit. We will need quite a bit of Ruridit for other processes and items, including the Assembly Line!"]
-			id: "40249CD28957E7EB"
-			rewards: [{
-				count: 6
-				id: "09A68E6B45224827"
-				item: "gtceu:ruthenium_dust"
-				random_bonus: 6
-				type: "item"
-			}]
-			subtitle: "Cleaned up the Dust"
-			tasks: [{
-				id: "270A0E25457E1C36"
-				item: "gtceu:ruthenium_dust"
-				type: "item"
-			}]
-			x: -2.0d
-			y: -3.0d
-		}
-		{
 			dependencies: ["318B71954A49DC27"]
 			description: [
 				"Parallelizing Hatches are going to be incredibly Important, especially moving forward with Large multiblock Structures!"
@@ -2485,6 +2266,26 @@
 			}]
 			x: -4.5d
 			y: 3.5d
+		}
+		{
+			dependencies: ["5A658F239928850E"]
+			description: ["Take that Ruthenium Dust and get to mixing! "]
+			hide_dependency_lines: true
+			id: "033BF8D12E32A5E5"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "4965B994720787A2"
+				table_id: 7041264405549027492L
+				type: "loot"
+			}]
+			subtitle: "All Mixed Up"
+			tasks: [{
+				id: "633D4D70BEFCEE0C"
+				item: "gtceu:iv_mixer"
+				type: "item"
+			}]
+			x: -1.0d
+			y: -3.0d
 		}
 	]
 	title: "Ludicrous Voltage"

--- a/config/ftbquests/quests/chapters/medium_voltage.snbt
+++ b/config/ftbquests/quests/chapters/medium_voltage.snbt
@@ -200,7 +200,7 @@
 				type: "item"
 			}]
 			x: 1.5d
-			y: 0.0d
+			y: -0.1d
 		}
 		{
 			dependencies: ["5E90EF7FF530C477"]
@@ -245,7 +245,7 @@
 				type: "item"
 			}]
 			x: -1.5d
-			y: 0.19999999999999996d
+			y: 0.5d
 		}
 		{
 			dependencies: ["707EBA5717938515"]
@@ -487,7 +487,7 @@
 				type: "item"
 			}]
 			x: -1.5d
-			y: -1.0d
+			y: -1.3000000000000003d
 		}
 		{
 			dependencies: [
@@ -524,7 +524,7 @@
 				type: "item"
 			}]
 			x: 1.5d
-			y: -1.0d
+			y: -1.3000000000000003d
 		}
 		{
 			dependencies: ["262AE37765B139BE"]
@@ -690,7 +690,7 @@
 			]
 			title: "Silicon ingredients"
 			x: 0.5d
-			y: -2.0d
+			y: -2.2d
 		}
 		{
 			dependencies: ["662E0A84D755064F"]
@@ -707,7 +707,7 @@
 				type: "item"
 			}]
 			x: 2.5d
-			y: 0.0d
+			y: -0.1d
 		}
 		{
 			dependencies: [
@@ -1419,7 +1419,7 @@
 				type: "item"
 			}]
 			x: -0.5d
-			y: -3.5d
+			y: -3.6d
 		}
 		{
 			dependencies: ["262AE37765B139BE"]
@@ -1437,7 +1437,7 @@
 				type: "item"
 			}]
 			x: -1.5d
-			y: -2.0d
+			y: -2.2d
 		}
 		{
 			dependencies: ["262AE37765B139BE"]
@@ -1459,7 +1459,7 @@
 				type: "item"
 			}]
 			x: -1.5d
-			y: -3.0d
+			y: -3.1d
 		}
 		{
 			dependencies: ["63621F0189B6EB1B"]
@@ -1478,12 +1478,13 @@
 				type: "item"
 			}]
 			x: -0.5d
-			y: -2.0d
+			y: -2.2d
 		}
 		{
 			dependencies: [
 				"1812BF72305CFFCF"
 				"54A164C737660C4E"
+				"3DCCEDC5A817EBEB"
 			]
 			description: ["Cook the dust up in the &aEBF&r and cool it down in the &eChemical Bath&r"]
 			id: "358706CA93DC2A9C"
@@ -1500,7 +1501,7 @@
 				type: "item"
 			}]
 			x: -0.5d
-			y: -1.0d
+			y: -1.3000000000000003d
 		}
 		{
 			dependencies: ["358706CA93DC2A9C"]
@@ -1530,7 +1531,89 @@
 				type: "item"
 			}]
 			x: 0.5d
-			y: -1.0d
+			y: -1.3000000000000003d
+		}
+		{
+			dependencies: ["1F92F7314DF3C3E2"]
+			description: [
+				"Follow the same steps as the Emerald/Ruby lens to make the &9Sapphire Lens&r"
+				""
+				"{\"clickEvent\": {\"action\": \"change_page\", \"value\": \"4DD7F3508B757EF0\"}, \"text\": \"How to make the gem plate\", \"color\": \"green\", \"hoverEvent\": { \"action\":\"show_text\", \"contents\": { \"text\":\"Click here for a reminder\" } }}"
+				""
+				"{\"clickEvent\": {\"action\": \"change_page\", \"value\": \"26004F997C758011\"}, \"text\": \"How to make the gem lens\", \"color\": \"yellow\", \"hoverEvent\": { \"action\":\"show_text\", \"contents\": { \"text\":\"Click here for a reminder\" } }}"
+			]
+			hide_dependency_lines: true
+			id: "20A0A574F51EEF74"
+			tasks: [{
+				id: "71285AC928BBD40E"
+				item: "gtceu:sapphire_lens"
+				type: "item"
+			}]
+			x: -3.5d
+			y: -0.20000000000000004d
+		}
+		{
+			dependencies: ["20A0A574F51EEF74"]
+			description: ["That's right, another &eLaser Engraver&r recipe... these quests are becoming non-linear"]
+			id: "5B92DA55541B168B"
+			rewards: [{
+				count: 2
+				id: "0B4A34429F4F377A"
+				item: "gtceu:silicon_wafer"
+				random_bonus: 2
+				type: "item"
+			}]
+			tasks: [{
+				id: "0B0A35D87D18E3A1"
+				item: "gtceu:ulpic_wafer"
+				type: "item"
+			}]
+			x: -2.5d
+			y: -0.4d
+		}
+		{
+			dependencies: ["5B92DA55541B168B"]
+			description: ["Back into the &ecutter&r!"]
+			id: "4E5FE40373675AED"
+			rewards: [{
+				id: "27DFB41D8F75BF3B"
+				type: "xp"
+				xp: 250
+			}]
+			tasks: [{
+				id: "1C973641E5F60EB4"
+				item: "gtceu:ulpic_chip"
+				type: "item"
+			}]
+			x: -1.5d
+			y: -0.4d
+		}
+		{
+			dependencies: ["4E5FE40373675AED"]
+			description: [
+				"You can use a GT Assembler or a regular crafting grid to make this. Since pattern space is precious, especially for the GT Assembler, perhaps a Crafter or Molecular Assembler can handle putting it together"
+				""
+				"Swap out the LV Energy Hatches on your &eElectric Blast Furnace&r for these and your EBF can now process &6HV&r recipes! "
+				""
+				"Make sure you upgrade your power source too! "
+			]
+			id: "3DCCEDC5A817EBEB"
+			min_width: 250
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "5FF28AC1A353565C"
+				table_id: 7083859357644513434L
+				type: "loot"
+			}]
+			subtitle: "EBF Upgrades"
+			tasks: [{
+				count: 2L
+				id: "3E686316F9E6B29E"
+				item: "gtceu:mv_energy_input_hatch"
+				type: "item"
+			}]
+			x: -0.5d
+			y: -0.20000000000000004d
 		}
 	]
 	title: "{atm9.chapters.28.title}"

--- a/config/ftbquests/quests/chapters/medium_voltage.snbt
+++ b/config/ftbquests/quests/chapters/medium_voltage.snbt
@@ -107,7 +107,7 @@
 				item: "gtceu:lv_circuit_assembler"
 				type: "item"
 			}]
-			x: -1.5d
+			x: -0.5d
 			y: -4.5d
 		}
 		{
@@ -115,6 +115,13 @@
 				"063F5023D56CA6B1"
 				"6A82827978D3483B"
 				"06BBD7B736C564C1"
+			]
+			description: [
+				"Transistors are truly a modern marvel and have allowed the electronic age to boom"
+				""
+				"They allow for much more complex electronics by amplifying signals and acting as a switch, introducing the capability for logic programming!"
+				""
+				"In our case, they allow us to make the Integrated Circuit!"
 			]
 			id: "0E603F1FE596DB2A"
 			rewards: [{
@@ -129,8 +136,8 @@
 				item: "gtceu:transistor"
 				type: "item"
 			}]
-			x: 1.5000000000000009d
-			y: 0.19999999999999996d
+			x: 2.0d
+			y: 1.0d
 		}
 		{
 			dependencies: ["100ADA8508F6502A"]
@@ -169,11 +176,8 @@
 			y: -1.4999999999999984d
 		}
 		{
-			dependencies: [
-				"54A164C737660C4E"
-				"2AB457E29360E3B8"
-			]
-			description: [""]
+			dependencies: ["2AB457E29360E3B8"]
+			description: ["Once cooled we can begin to shape the ingot into more useful materials"]
 			id: "662E0A84D755064F"
 			rewards: [
 				{
@@ -195,8 +199,8 @@
 				item: "gtceu:silicon_ingot"
 				type: "item"
 			}]
-			x: 0.5d
-			y: -1.0d
+			x: 1.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["5E90EF7FF530C477"]
@@ -221,8 +225,8 @@
 				item: "gtceu:polyethylene_bucket"
 				type: "item"
 			}]
-			x: 1.5d
-			y: 1.4d
+			x: 1.0d
+			y: 1.5d
 		}
 		{
 			dependencies: ["262AE37765B139BE"]
@@ -486,7 +490,10 @@
 			y: -1.0d
 		}
 		{
-			dependencies: ["589F47DE51213920"]
+			dependencies: [
+				"589F47DE51213920"
+				"72E5439299E957A8"
+			]
 			description: [
 				"Put those dusts we just made into your electric blast furnace and get some hot silicon!"
 				""
@@ -516,8 +523,8 @@
 				item: "gtceu:hot_silicon_ingot"
 				type: "item"
 			}]
-			x: 0.5d
-			y: -2.0d
+			x: 1.5d
+			y: -1.0d
 		}
 		{
 			dependencies: ["262AE37765B139BE"]
@@ -682,11 +689,12 @@
 				}
 			]
 			title: "Silicon ingredients"
-			x: -0.5d
+			x: 0.5d
 			y: -2.0d
 		}
 		{
 			dependencies: ["662E0A84D755064F"]
+			description: ["This Silicon Plate will allow us to make the Transistor! A new electrical component, yay!"]
 			id: "06BBD7B736C564C1"
 			rewards: [{
 				id: "7154B2B74B4F5FAC"
@@ -698,8 +706,8 @@
 				item: "gtceu:silicon_plate"
 				type: "item"
 			}]
-			x: 1.5d
-			y: -1.0d
+			x: 2.5d
+			y: 0.0d
 		}
 		{
 			dependencies: [
@@ -847,7 +855,7 @@
 				item: "gtceu:mv_polarizer"
 				type: "item"
 			}]
-			x: -1.5d
+			x: -6.0d
 			y: -3.0d
 		}
 		{
@@ -949,8 +957,8 @@
 				item: "gtceu:magnetic_steel_rod"
 				type: "item"
 			}]
-			x: -0.5d
-			y: -3.0d
+			x: -5.0d
+			y: -3.5d
 		}
 		{
 			dependencies: ["72DACA35906D7E5B"]
@@ -1385,6 +1393,8 @@
 				"63621F0189B6EB1B"
 				"7963008B930D84BB"
 			]
+			description: ["A necessary component for the &bMV Cutter&r"]
+			hide_dependent_lines: true
 			id: "707EBA5717938515"
 			rewards: [
 				{
@@ -1408,13 +1418,12 @@
 				item: "gtceu:vanadium_steel_ingot"
 				type: "item"
 			}]
-			x: 8.5d
-			y: 0.5d
+			x: -0.5d
+			y: -3.5d
 		}
 		{
 			dependencies: ["262AE37765B139BE"]
 			description: ["Making &bvanadium steel dust&r is an MV recipe in the Mixer, so it is time for an upgrade! "]
-			hide_dependency_lines: true
 			id: "63621F0189B6EB1B"
 			rewards: [{
 				exclude_from_claim_all: true
@@ -1427,13 +1436,16 @@
 				item: "gtceu:mv_mixer"
 				type: "item"
 			}]
-			x: 10.0d
-			y: -0.5d
+			x: -1.5d
+			y: -2.0d
 		}
 		{
 			dependencies: ["262AE37765B139BE"]
-			description: ["This machine is very useful for acquiring &dchromium dust&r, which we'll need to make &bstainless steel dust&r and &bvanadium steel dust&r"]
-			hide_dependency_lines: true
+			description: [
+				"This machine is very useful for acquiring &dchromium dust&r, which we'll need to make &bstainless steel dust&r and &bvanadium steel dust&r"
+				""
+				"You could chain process Redstone Dust for Ruby Dust to then &eElectrolyze&r for &dChromium Dust&r"
+			]
 			id: "7963008B930D84BB"
 			rewards: [{
 				exclude_from_claim_all: true
@@ -1446,8 +1458,79 @@
 				item: "gtceu:mv_electrolyzer"
 				type: "item"
 			}]
-			x: 10.0d
-			y: 1.5d
+			x: -1.5d
+			y: -3.0d
+		}
+		{
+			dependencies: ["63621F0189B6EB1B"]
+			description: ["Put Aluminium dust, Iron dust, and Chromium dust together in a &eMixer&r and watch it blend!"]
+			id: "1812BF72305CFFCF"
+			rewards: [{
+				count: 4
+				id: "74819F7F2D53028B"
+				item: "gtceu:chromium_dust"
+				random_bonus: 4
+				type: "item"
+			}]
+			tasks: [{
+				id: "2CF35B15AD75E179"
+				item: "gtceu:kanthal_dust"
+				type: "item"
+			}]
+			x: -0.5d
+			y: -2.0d
+		}
+		{
+			dependencies: [
+				"1812BF72305CFFCF"
+				"54A164C737660C4E"
+			]
+			description: ["Cook the dust up in the &aEBF&r and cool it down in the &eChemical Bath&r"]
+			id: "358706CA93DC2A9C"
+			rewards: [{
+				count: 4
+				id: "71E792F83E0444B2"
+				item: "gtceu:chromium_dust"
+				random_bonus: 4
+				type: "item"
+			}]
+			tasks: [{
+				id: "4E1E15185D672109"
+				item: "gtceu:kanthal_ingot"
+				type: "item"
+			}]
+			x: -0.5d
+			y: -1.0d
+		}
+		{
+			dependencies: ["358706CA93DC2A9C"]
+			description: [
+				"Use that &eExtractor&r to get your copper in a liquid state"
+				""
+				"&eWire Cut&r the Kanthal ingots"
+				""
+				"&eBend&r that Aluminium"
+				""
+				"Then put it all together in your &eAssembler&r!"
+				""
+				"Replace the Cupronickel Coils on your &aEBF&r with this stuff"
+			]
+			id: "72E5439299E957A8"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "086F84F7B79F7B8B"
+				table_id: 7083859357644513434L
+				type: "loot"
+			}]
+			shape: "gear"
+			tasks: [{
+				count: 16L
+				id: "6C8DCC0E471D0163"
+				item: "gtceu:kanthal_coil_block"
+				type: "item"
+			}]
+			x: 0.5d
+			y: -1.0d
 		}
 	]
 	title: "{atm9.chapters.28.title}"

--- a/config/ftbquests/quests/chapters/mekanism_reactors.snbt
+++ b/config/ftbquests/quests/chapters/mekanism_reactors.snbt
@@ -1917,9 +1917,15 @@
 			]
 			shape: "hexagon"
 			tasks: [{
-				count: 4L
 				id: "31A1425AA09C33F8"
-				item: "mekanism:dust_lithium"
+				item: {
+					Count: 1b
+					id: "itemfilters:tag"
+					tag: {
+						value: "forge:dusts/lithium"
+					}
+				}
+				title: "Lithium Dust"
 				type: "item"
 			}]
 			title: "Advanced Power Storage"

--- a/config/ftbquests/quests/chapters/refined_storage.snbt
+++ b/config/ftbquests/quests/chapters/refined_storage.snbt
@@ -1497,58 +1497,6 @@
 			y: -1.0d
 		}
 		{
-			dependencies: ["718A2040D868E09F"]
-			description: ["Infinite item storage!"]
-			hide_dependency_lines: false
-			id: "61D4080EC66A57DE"
-			rewards: [
-				{
-					id: "4B33D2CCD34DB34B"
-					table_id: 4001436279668650237L
-					type: "random"
-				}
-				{
-					id: "72250B23E6B0E5F4"
-					table_id: 1739527894044761161L
-					type: "random"
-				}
-			]
-			shape: "diamond"
-			tasks: [{
-				id: "4A52CA691C535DE8"
-				item: "extradisks:infinite_storage_part"
-				type: "item"
-			}]
-			x: 0.0d
-			y: 4.5d
-		}
-		{
-			dependencies: ["49772923B8AF0F1F"]
-			description: ["Infinite fluid storage!"]
-			hide_dependency_lines: false
-			id: "1D483A4F8A2E48C5"
-			rewards: [
-				{
-					id: "0FED744A44F71189"
-					table_id: 3567941291661635734L
-					type: "random"
-				}
-				{
-					id: "0315A15FD7D5B1AC"
-					table_id: 4001436279668650237L
-					type: "random"
-				}
-			]
-			shape: "diamond"
-			tasks: [{
-				id: "48E0006E9C8D0BC9"
-				item: "extradisks:infinite_fluid_storage_part"
-				type: "item"
-			}]
-			x: -3.0d
-			y: 4.5d
-		}
-		{
 			dependencies: [
 				"4B81E84CAE814BA9"
 				"4101F8275B41C79B"

--- a/config/ftbquests/quests/chapters/steam_age.snbt
+++ b/config/ftbquests/quests/chapters/steam_age.snbt
@@ -308,6 +308,7 @@
 				"73FC1166FBD6C30D"
 				"506360EEA2268E82"
 				"1E811D532BC593F2"
+				"49D740C5B5EB593C"
 			]
 			description: [
 				"All LV Machines are gated behind this circuit"
@@ -352,7 +353,7 @@
 				type: "item"
 			}]
 			x: 5.0d
-			y: 2.0d
+			y: 3.0d
 		}
 		{
 			description: [
@@ -450,7 +451,7 @@
 			]
 			title: "Glass Tube"
 			x: 0.0d
-			y: 2.0d
+			y: 3.0d
 		}
 		{
 			dependencies: ["7A62C1B9385DF643"]
@@ -477,7 +478,7 @@
 				type: "item"
 			}]
 			x: 3.5d
-			y: 2.0d
+			y: 3.0d
 		}
 		{
 			dependencies: ["60069A897F2B0F78"]
@@ -697,6 +698,45 @@
 			}]
 			x: -6.5d
 			y: -2.0d
+		}
+		{
+			dependencies: ["6ECBB6F5D0D99DEE"]
+			description: ["One &6Copper Ingot&r and four &cRedstone Dust&r in the &eAlloy Smelter&r creates this lovely ingot"]
+			id: "3302A9306CAD659A"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "3B3B4D9925B69097"
+				table_id: 4444697382338980938L
+				type: "loot"
+			}]
+			tasks: [{
+				id: "4F21E8821A465876"
+				item: "gtceu:red_alloy_ingot"
+				type: "item"
+			}]
+			x: 1.0d
+			y: 2.0d
+		}
+		{
+			dependencies: [
+				"3302A9306CAD659A"
+				"6CE157D05F59A994"
+			]
+			description: ["Red Alloy Cable is an integral part of crafting the &bLV Circuit&r and getting out of the Steam Age"]
+			id: "49D740C5B5EB593C"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "393B393299331031"
+				table_id: 4444697382338980938L
+				type: "loot"
+			}]
+			tasks: [{
+				id: "31DEB8892D2B486F"
+				item: "gtceu:red_alloy_single_cable"
+				type: "item"
+			}]
+			x: 3.0d
+			y: 2.0d
 		}
 	]
 	title: "{atm9.chapters.26.title}"

--- a/config/ftbquests/quests/chapters/ultimate_voltage.snbt
+++ b/config/ftbquests/quests/chapters/ultimate_voltage.snbt
@@ -896,7 +896,7 @@
 					id: "36D48825566366AE"
 					observe_type: 0
 					timer: 0L
-					to_observe: "gtceu:fusion_reactor_mk_ii"
+					to_observe: "gtceu:zpm_fusion_reactor"
 					type: "observation"
 				}
 			]

--- a/config/ftbquests/quests/reward_tables/Tier5_SeedBag.snbt
+++ b/config/ftbquests/quests/reward_tables/Tier5_SeedBag.snbt
@@ -10,7 +10,6 @@
 		{ item: "mysticalagriculture:netherite_seeds" }
 		{ item: "mysticalagriculture:wither_skeleton_seeds", weight: 3.0f }
 		{ item: "mysticalagriculture:platinum_seeds", weight: 3.0f }
-		{ item: "mysticalagriculture:iridium_seeds", weight: 3.0f }
 		{ item: "mysticalagriculture:enderium_seeds" }
 		{ item: "mysticalagriculture:uraninite_seeds", weight: 3.0f }
 		{ item: "mysticalagriculture:supremium_furnace", weight: 3.0f }

--- a/kubejs/server_scripts/mods/gtceu/mega_fusion_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/mega_fusion_recipes.js
@@ -20,8 +20,8 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.mega_fusion_reactor('star_matter')
         .inputFluids([
-            Fluid.of('gtceu:hydrogen_plasma', 10000), 
-            Fluid.of('gtceu:helium_plasma', 2500), 
+            Fluid.of('gtceu:helium_plasma', 10000), 
+            Fluid.of('gtceu:nitrogen_plasma', 2500), 
             Fluid.of('gtceu:oxygen_plasma', 1500), 
             Fluid.of('gtceu:iron_plasma', 250)
         ])

--- a/kubejs/server_scripts/mods/gtceu/mining_dim_ores.js
+++ b/kubejs/server_scripts/mods/gtceu/mining_dim_ores.js
@@ -31,18 +31,34 @@ GTCEuServerEvents.oreVeins(event => {
         let veinGen = vein.veinGenerator();
         if (veinGen instanceof $VeinedVeinGenerator) {
             veinGen = veinGen.copy()
-            veinGen.minYLevel = startY;
-            veinGen.maxYLevel = endY;
+            veinGen.minYLevel(startY);
+            veinGen.maxYLevel(endY);
+            // veinGen.minYLevel = startY;
+            // veinGen.maxYLevel = endY;
         } else if (veinGen instanceof $DikeVeinGenerator) {
             veinGen = veinGen.copy()
-            veinGen.minYLevel = startY;
-            veinGen.maxYLevel = endY;
+            veinGen.minYLevel(startY);
+            veinGen.maxYLevel(endY);
+            var blocks = veinGen.getAllEntries()
+            blocks.forEach((block) => {
+                veinGen.withBlock(new GTDikeBlockDefinition['(com.mojang.datafixers.util.Either,int,int,int)'](block.key, block.value, startY, endY))
+            })
+            // veinGen.minYLevel = startY;
+            // veinGen.maxYLevel = endY;
         }
+
+        
         
         vein.heightRangeUniform(startY, endY)
         vein.dimensions('allthemodium:mining')
         vein.biomes('#allthemodium:mining_features/mining_biomes')
         vein['veinGenerator(com.gregtechceu.gtceu.api.data.worldgen.generator.VeinGenerator)'](veinGen)
+        // vein.surfaceIndicatorGenerator(indicator => indicator
+        //     .block(Block.getBlock("minecraft:air"))
+        //     .placement("above")
+        //     .density(0.4)
+        //     .radius(5))
+
 
         // event.add(veinId + '_mining', newVein => {
         //     let veinGen = vein.veinGenerator();
@@ -76,12 +92,12 @@ GTCEuServerEvents.oreVeins(event => {
             .layer('deepslate')
             .dimensions('allthemodium:mining')
             .biomes('#allthemodium:mining_features/mining_biomes')
-            .heightRangeUniform(-50, 10)
+            .heightRangeUniform(65, 128)
             .dikeVeinGenerator(generator => 
-                generator.withBlock(new GTDikeBlockDefinition['(com.gregtechceu.gtceu.api.data.chemical.material.Material,int,int,int)'](GTMaterials.get("fluorite"), 3, -64, 320))
-                        .withBlock(new GTDikeBlockDefinition['(com.gregtechceu.gtceu.api.data.chemical.material.Material,int,int,int)'](GTMaterials.get("sulfur"), 1, -64, 320))
-                        .withBlock(new GTDikeBlockDefinition['(com.gregtechceu.gtceu.api.data.chemical.material.Material,int,int,int)'](GTMaterials.get("gypsum"), 2, -64, 320))
-                        .withBlock(new GTDikeBlockDefinition['(com.gregtechceu.gtceu.api.data.chemical.material.Material,int,int,int)'](GTMaterials.get("dolomite"), 1, -64, 320))
+                generator.withBlock(new GTDikeBlockDefinition['(com.gregtechceu.gtceu.api.data.chemical.material.Material,int,int,int)'](GTMaterials.get("fluorite"), 3, 65, 128))
+                        .withBlock(new GTDikeBlockDefinition['(com.gregtechceu.gtceu.api.data.chemical.material.Material,int,int,int)'](GTMaterials.get("sulfur"), 1, 65, 128))
+                        .withBlock(new GTDikeBlockDefinition['(com.gregtechceu.gtceu.api.data.chemical.material.Material,int,int,int)'](GTMaterials.get("gypsum"), 2, 65, 128))
+                        .withBlock(new GTDikeBlockDefinition['(com.gregtechceu.gtceu.api.data.chemical.material.Material,int,int,int)'](GTMaterials.get("dolomite"), 1, 65, 128))
             )
         })
 })

--- a/kubejs/server_scripts/mods/gtceu/starforge_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/starforge_recipes.js
@@ -11,15 +11,20 @@ ServerEvents.recipes(event => {
 			fluid = null
 		}
 	} 
-	// Gregstar Components
+	// Gregstar Components with fluids
 	starForge('robust_star_housing', 4000, ZPM, 'kubejs:star_housing', ['allthetweaks:patrick_star', '32x gtceu:tungsten_steel_double_plate', '64x gtceu:tungsten_steel_screw'], [Fluid.of('gtceu:oxygen_plasma', 2880), Fluid.of('gtceu:nitrogen_plasma', 2880), Fluid.of('gtceu:argon_plasma', 2880), Fluid.of('gtceu:helium_plasma', 2880)])
 	starForge('absolute_reaction_plating', 1000, ZPM, 'kubejs:absolute_reaction_plating', ['gtceu:neutronium_block', '16x gtceu:fusion_coil', '16x gtceu:fusion_casing_mk3', '16x gtceu:fusion_glass'], Fluid.of('gtceu:uranium_235', 2000))
-	starForge('star_compression_module', 1000, ZPM, 'kubejs:star_compression_module', ['allthetweaks:atm_star', '16x gtceu:energy_cluster', '4x gtceu:uv_transformer_16a', '4x gtceu:uv_energy_input_hatch_16a'])
 	starForge('superthermal_transference_coil', 1000, ZPM, 'kubejs:superthermal_transference_coil', ['16x gtceu:uv_voltage_coil', '16x gtceu:tritanium_coil_block', '4x gtceu:uv_naquadria_battery'], Fluid.of('gtceu:europium', 2000))
 	starForge('cable_of_hyperconductivity', 1000, ZPM, 'kubejs:cable_of_hyperconductivity', ['8x gtceu:manganese_phosphide_hex_wire', '8x gtceu:magnesium_diboride_hex_wire', '8x gtceu:mercury_barium_calcium_cuprate_hex_wire', '8x gtceu:uranium_triplatinum_hex_wire', '8x gtceu:samarium_iron_arsenic_oxide_hex_wire', '8x gtceu:indium_tin_barium_titanium_cuprate_hex_wire', '8x gtceu:uranium_rhodium_dinaquadide_hex_wire','8x gtceu:enriched_naquadah_trinium_europium_duranide_hex_wire'], [Fluid.of('gtceu:styrene_butadiene_rubber', 16000), Fluid.of('gtceu:silicone_rubber', 32000), Fluid.of('gtceu:rubber', 64000)])
+	
+	// star compression module
+	event.recipes.gtceu.star_forge('star_compression_module')
+		.itemInputs(['allthetweaks:atm_star', '16x gtceu:energy_cluster', '4x gtceu:uv_transformer_16a', '4x gtceu:uv_energy_input_hatch_16a'])
+		.itemOutputs('kubejs:star_compression_module')
+		.duration(1000)
+		.EUt(ZPM)
 
-
-	// Micro Universe Orb
+	// Micro Universe Catalyst
 	starForge('micro_universe_catalyst', 2000, UV, 'kubejs:micro_universe_catalyst', ['16x gtceu:naquadria_plate', '32x gtceu:uv_electric_piston', '8x gtceu:gravi_star'], [Fluid.of('gtceu:neutronium', 144 * 32), Fluid.of('gtceu:star_matter_plasma', 10000)])
 
 	// Gregstar
@@ -53,16 +58,17 @@ ServerEvents.recipes(event => {
 		.EUt(ZPM)
 
 	// Gregstar creative uses
-	starForge('infinite_polonium', 4000, ZPM, 
-		Item.of('mekanism:creative_chemical_tank', '{mekData: {GasTanks: [{Tank: 0b, stored: {gasName: "mekanism:polonium", amount: 9223372036854775807L}}]}}'),
-		['1000x mekanism:pellet_polonium',
-		'2x kubejs:greg_star_shard'],
-	)
-	starForge('infinite_plutonium', 4000, ZPM, 
-		Item.of('mekanism:creative_chemical_tank', '{mekData: {GasTanks: [{Tank: 0b, stored: {gasName: "mekanism:plutonium", amount: 9223372036854775807L}}]}}'),
-		['1000x mekanism:pellet_plutonium',
-		'2x kubejs:greg_star_shard'],
-	)
+	event.recipes.gtceu.star_forge('infinite_polonium')
+		.itemInputs(['1000x mekanism:pellet_polonium', '2x kubejs:greg_star_shard'])
+		.itemOutputs(Item.of('mekanism:creative_chemical_tank', '{mekData: {GasTanks: [{Tank: 0b, stored: {gasName: "mekanism:polonium", amount: 9223372036854775807L}}]}}'))
+		.duration(4000)
+		.EUt(ZPM)
+	
+	event.recipes.gtceu.star_forge('infinite_plutonium')
+		.itemInputs(['1000x mekanism:pellet_plutonium', '2x kubejs:greg_star_shard'])
+		.itemOutputs(Item.of('mekanism:creative_chemical_tank', '{mekData: {GasTanks: [{Tank: 0b, stored: {gasName: "mekanism:plutonium", amount: 9223372036854775807L}}]}}'))
+		.duration(4000)
+		.EUt(ZPM)
 
 	// Other Star Forge Recipes
 	event.recipes.gtceu.star_forge('atm_star')


### PR DESCRIPTION
A whole lot of quest adjustments, detailed below!

- GT's Getting Started chapter, added some info about how GT ores are only in the mining dimension
- Red Alloy added to Steam Age as a prerequisite to the LV circuit
- Kanthal Coils were moved from EV chapter to MV chapter as a prerequisite for Silicon Ingots
- Fixed a typo in the UV chapter that prevented the MK2 Fusion Reactor quest from being completed
- Changed the Lithium Dust quest in Mekanism: Advanced chapter to accept any Lithium Dust
- Removed the Infinite Storage Fluid & Item Parts from the Refind Storage chapter since they cannot be crafted
- Removed Iridium Seeds as a quest reward since those seeds cannot be used
- Edited Chapter 2 questline to add the new ATM Star items and remove the old items
- Moved Ruthenium Dust processing out of LuV chapter and into the IV chapter as prerequisites for the RTM Alloy Coil quest