### PR TITLE
Entangled Unblock Refined Storage & AE2 Entaglement

### DIFF
--- a/kubejs/data/entangled/tags/blocks/invalid_targets.json
+++ b/kubejs/data/entangled/tags/blocks/invalid_targets.json
@@ -1,0 +1,4 @@
+{
+  "replace": true,
+  "values": []
+}


### PR DESCRIPTION
Via a simple change to the data at entangled/tags/blocks/invalid_targets.json which normally contains wildcard modifiers blocking AE2 + Refined storage entanglement we can replace those values and re-enable it