### PR TITLE
Allow new GT bees to exist without overriding

### DIFF
--- a/config/ftbquests/quests/chapters/mainquestline_part_1.snbt
+++ b/config/ftbquests/quests/chapters/mainquestline_part_1.snbt
@@ -2465,7 +2465,7 @@
 				Count: 1b
 				id: "ftbquests:custom_icon"
 				tag: {
-					Icon: "productivebees:textures/advancements/all_bees.png"
+					Icon: "productivebees:textures/item/all_bees.png"
 				}
 			}
 			id: "086A3E80E57D46BE"

--- a/kubejs/data/productivebees/productivebees/chemlib/neodymium.json
+++ b/kubejs/data/productivebees/productivebees/chemlib/neodymium.json
@@ -1,13 +1,24 @@
 {
-    "primaryColor": "#998784",
-    "particleColor": "#ab9d9a",
-    "beeTexture": "productivebees:textures/entity/bee/neodymium/bee",
-    "description": "productivebees.ingredient.description.only_spawnegg",
-    "flowerItem": "chemlib:neodymium",
-    "conditions": [
-      {
+  "primaryColor": "#998784",
+  "particleColor": "#ab9d9a",
+  "beeTexture": "productivebees:textures/entity/bee/neodymium/bee",
+  "description": "productivebees.ingredient.description.only_spawnegg",
+  "flowerItem": "chemlib:neodymium",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "chemlib"
+    },
+    {
+      "type": "forge:tag_empty",
+      "tag": "forge:raw_materials/neodymium"
+    },
+    {
+      "type": "forge:not",
+      "value": {
         "type": "forge:mod_loaded",
-        "modid": "chemlib"
+        "modid": "gtceu"
       }
-    ]
-  }
+    }
+  ]
+}

--- a/kubejs/data/productivebees/productivebees/chemlib/palladium.json
+++ b/kubejs/data/productivebees/productivebees/chemlib/palladium.json
@@ -1,12 +1,23 @@
 {
-    "primaryColor": "#b78187",
-    "particleColor": "#c3989a",
-    "beeTexture": "productivebees:textures/entity/bee/palladium/bee",
-    "flowerItem": "chemlib:palladium",
-    "conditions": [
-      {
+  "primaryColor": "#b78187",
+  "particleColor": "#c3989a",
+  "beeTexture": "productivebees:textures/entity/bee/palladium/bee",
+  "flowerItem": "chemlib:palladium",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "chemlib"
+    },
+    {
+      "type": "forge:tag_empty",
+      "tag": "forge:raw_materials/palladium"
+    },
+    {
+      "type": "forge:not",
+      "value": {
         "type": "forge:mod_loaded",
-        "modid": "chemlib"
+        "modid": "gtceu"
       }
-    ]
-  }
+    }
+  ]
+}

--- a/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
@@ -21,7 +21,7 @@ ServerEvents.recipes(event => {
         .itemInputs([
             '1x gtceu:atomic_casing',
             '24x gtceu:tungsten_steel_screw',
-            '6x gtceu:rhodium_plated_palladium_dense_plate',
+            '6x gtceu:dense_rhodium_plated_palladium_plate',
             '16x gtceu:enriched_naquadah_trinium_europium_duranide_hex_wire',
             '4x gtceu:uv_field_generator',
             '2x gtceu:fusion_coil',
@@ -38,7 +38,7 @@ ServerEvents.recipes(event => {
         .itemInputs([
             '1x gtceu:atomic_casing',
             '24x gtceu:tungsten_steel_screw',
-            '6x gtceu:rhodium_plated_palladium_dense_plate',
+            '6x gtceu:dense_rhodium_plated_palladium_plate',
             '1x #forge:lenses/orange',
             '1x kubejs:superthermal_transference_coil',
             '1x kubejs:absolute_reaction_plating'


### PR DESCRIPTION
Adds a new condition that prevents the override for Chemlib Neodymium and Palladium bees from working, allowing the new GT raw ore Neodymium and Palladium bees to work as intended.