### PR TITLE
Unify Fig, convert between Mercury types, add tags to mined stuff

### DIFF
--- a/kubejs/server_scripts/mods/chemlib/craftRemove.js
+++ b/kubejs/server_scripts/mods/chemlib/craftRemove.js
@@ -66,4 +66,72 @@ ServerEvents.recipes(event => {
             "weighted": false
         }
     })
+    
+    event.custom({
+        "type": "alchemistry:dissolver",
+        "group": "alchemistry:dissolver",
+        "input": {
+            "count": 1,
+            "ingredient": {
+              "item": "'theurgy:mercury_shard'"
+            }
+        },
+        "output": {
+            "groups": [
+                {
+                    "probability": 100.0,
+                    "results": [
+                        {
+                            "count": 1,
+                            "item": "chemlib:mercury"
+                        }
+                    ]
+                }
+            ],
+            "rolls": 1,
+            "weighted": false
+        }
+    })
+
+    event.custom({
+        "type": "alchemistry:dissolver",
+        "group": "alchemistry:dissolver",
+        "input": {
+            "count": 1,
+            "ingredient": {
+              "item": "'theurgy:mercury_shard'"
+            }
+        },
+        "output": {
+            "groups": [
+                {
+                    "probability": 100.0,
+                    "results": [
+                        {
+                            "count": 1,
+                            "item": "chemlib:mercury"
+                        }
+                    ]
+                }
+            ],
+            "rolls": 1,
+            "weighted": false
+        }
+    })
+    
+    event.custom({
+	  "type": "alchemistry:combiner",
+	  "group": "alchemistry:combiner",
+	  "input": [
+		{
+		  "count": 1,
+		  "ingredient": {
+		    "item": "chemlib:mercury"
+		  }
+		}
+	  ],
+	  "result": {
+		"item": "theurgy:mercury_shard"
+	  }
+	})
 })

--- a/kubejs/server_scripts/mods/croptopia/fig.js
+++ b/kubejs/server_scripts/mods/croptopia/fig.js
@@ -1,0 +1,8 @@
+// priority: 10
+ServerEvents.recipes(event => {
+	event.remove({id: 'croptopia:fig_sapling'})
+    event.shapeless('croptopia:fig_sapling', ['#forge:fruits/fig', '#forge:fruits/fig', '#minecraft:saplings'])
+    
+    event.remove({id: 'croptopia:shaped_figgy_pudding'})
+    event.shaped('croptopia:figgy_pudding', ['   ', 'ABC', 'DEF'], {'A': 'croptopia:date', 'B': '#forge:fruits/fig', 'C': 'minecraft:sugar', 'D': 'minecraft:egg', 'E': '#forge:water_bottles', 'F': 'croptopia:whipping_cream'})
+});

--- a/kubejs/server_scripts/mods/croptopia/tags.js
+++ b/kubejs/server_scripts/mods/croptopia/tags.js
@@ -1,0 +1,8 @@
+ServerEvents.tags('item', event => {
+  // Unify croptopia and cauponia fig
+  event.add('forge:crops', 'cauponia:fig')
+  event.add('forge:crops/fig', 'cauponia:fig')
+  event.add('forge:figs', 'cauponia:fig')
+  event.add('forge:fruits', 'cauponia:fig')
+  event.add('forge:fruits/fig', 'cauponia:fig')
+});

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -112,6 +112,11 @@ ServerEvents.tags('item', event => {
   event.add('forge:raw_materials/elementium', 'mythicbotany:raw_elementium')
   event.add('forge:storage_blocks/raw_elementium', 'mythicbotany:raw_elementium_block')
 
+  // Add 'dust' tag to Inferium essence, 'gem' tag to Dark Gem (EvilCraft) and Prosperity Shard (MA)
+  event.add('forge:dusts', 'mysticalagriculture:inferium_essence')
+  event.add('forge:gems', 'evilcraft:dark_gem')
+  event.add('forge:gems', 'mysticalagriculture:prosperity_shard')
+
   event.remove('forge:shears', 'allthemodium:alloy_paxel')
   
   event.remove('forge:ingots/naquadah', 'sgjourney:naquadah')


### PR DESCRIPTION
* Unify Cauponia and Croptopia Figs
* Add `forge:dusts` tag to Inferium Essence
* Add `forge:gems` tag to Dark Gem (Evilcraft) and Prosperity Shard
* Allow converting between Alchemistry and Theurgy mercury

**Notice** For some reason `kubejs/server_scripts/mods/croptopia/fig.js` and `kubejs/server_scripts/mods/croptopia/tags.js` are loaded, but not executed.

Please let me know if you prefer to have each change in it's own PR.