### PR TITLE
Add new drops to wannabee/drygmy farms

### DIFF
--- a/kubejs/data/forge/loot_modifiers/global_loot_modifiers.json
+++ b/kubejs/data/forge/loot_modifiers/global_loot_modifiers.json
@@ -1,0 +1,15 @@
+{
+    "replace": false,
+    "entries": [
+      "modpack:wither_nether_star_drygmy",
+      "modpack:ender_dragon_drygmy",
+      "modpack:warden_drygmy",
+      "modpack:wilden_chimera_drygmy",
+      "modpack:wither_bhc_wannabee",
+      "modpack:ender_dragon_wannabee",
+      "modpack:warden_wannabee",
+      "modpack:wilden_chimera_wannabee",
+      "modpack:chicken_wannabee",
+      "modpack:turtle_wannabee"
+    ]
+  }

--- a/kubejs/data/modpack/loot_modifiers/chicken_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/chicken_wannabee.json
@@ -1,0 +1,17 @@
+{
+    "conditions": [
+      {
+        "condition": "forge:loot_table_id",
+        "loot_table_id": "minecraft:entities/chicken"
+      },
+      {
+        "condition": "productivebees:killed_by_uuid",
+        "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
+      }
+    ],
+    "type": "productivebees:ingredient_modifier",
+    "chance": 0.25,
+    "addition": {
+        "item": "minecraft:egg"
+    }
+  }

--- a/kubejs/data/modpack/loot_modifiers/chicken_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/chicken_wannabee.json
@@ -5,7 +5,7 @@
         "loot_table_id": "minecraft:entities/chicken"
       },
       {
-        "condition": "productivebees:killed_by_uuid",
+        "condition": "productivelib:killed_by_uuid",
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],

--- a/kubejs/data/modpack/loot_modifiers/chicken_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/chicken_wannabee.json
@@ -9,7 +9,7 @@
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],
-    "type": "productivebees:ingredient_modifier",
+    "type": "productivelib:ingredient_modifier",
     "chance": 0.25,
     "addition": {
         "item": "minecraft:egg"

--- a/kubejs/data/modpack/loot_modifiers/ender_dragon_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/ender_dragon_drygmy.json
@@ -1,0 +1,42 @@
+{
+    "conditions": [
+      {
+        "condition": "forge:loot_table_id",
+        "loot_table_id": "minecraft:entities/ender_dragon"
+      },
+      {
+        "condition": "productivebees:killed_by_uuid",
+        "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
+      }
+    ],
+    "type": "productivebees:ingredient_modifier",
+    "chance": 0.5,
+    "addition": [{
+        "item": "mysticalagriculture:cognizant_dust"
+    },
+    {
+        "item": "ends_delight:dragon_tooth"
+    },
+    {
+        "item": "minecraft:dragon_egg"
+    },
+    {
+        "item": "minecraft:dragon_head"
+    },
+    {
+        "item": "minecraft:dragon_breath"
+    },
+    {
+        "item": "mysticalagradditions:dragon_scale"
+    },
+    {
+        "item": "ends_delight:dragon_leg"
+    },
+    {
+        "item": "quark:dragon_scale"
+    },
+    {
+        "item": "bhc:green_heart"
+    }
+    ]
+  }

--- a/kubejs/data/modpack/loot_modifiers/ender_dragon_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/ender_dragon_drygmy.json
@@ -9,7 +9,7 @@
         "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
       }
     ],
-    "type": "productivebees:ingredient_modifier",
+    "type": "productivelib:ingredient_modifier",
     "chance": 0.5,
     "addition": [{
         "item": "mysticalagriculture:cognizant_dust"

--- a/kubejs/data/modpack/loot_modifiers/ender_dragon_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/ender_dragon_drygmy.json
@@ -5,7 +5,7 @@
         "loot_table_id": "minecraft:entities/ender_dragon"
       },
       {
-        "condition": "productivebees:killed_by_uuid",
+        "condition": "productivelib:killed_by_uuid",
         "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
       }
     ],

--- a/kubejs/data/modpack/loot_modifiers/ender_dragon_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/ender_dragon_wannabee.json
@@ -1,0 +1,42 @@
+{
+    "conditions": [
+      {
+        "condition": "forge:loot_table_id",
+        "loot_table_id": "minecraft:entities/ender_dragon"
+      },
+      {
+        "condition": "productivebees:killed_by_uuid",
+        "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
+      }
+    ],
+    "type": "productivebees:ingredient_modifier",
+    "chance": 0.15,
+    "addition": [{
+        "item": "mysticalagriculture:cognizant_dust"
+    },
+    {
+        "item": "ends_delight:dragon_tooth"
+    },
+    {
+        "item": "minecraft:dragon_egg"
+    },
+    {
+        "item": "minecraft:dragon_head"
+    },
+    {
+        "item": "minecraft:dragon_breath"
+    },
+    {
+        "item": "mysticalagradditions:dragon_scale"
+    },
+    {
+        "item": "ends_delight:dragon_leg"
+    },
+    {
+        "item": "quark:dragon_scale"
+    },
+    {
+        "item": "bhc:green_heart"
+    }
+    ]
+  }

--- a/kubejs/data/modpack/loot_modifiers/ender_dragon_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/ender_dragon_wannabee.json
@@ -5,7 +5,7 @@
         "loot_table_id": "minecraft:entities/ender_dragon"
       },
       {
-        "condition": "productivebees:killed_by_uuid",
+        "condition": "productivelib:killed_by_uuid",
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],

--- a/kubejs/data/modpack/loot_modifiers/ender_dragon_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/ender_dragon_wannabee.json
@@ -9,7 +9,7 @@
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],
-    "type": "productivebees:ingredient_modifier",
+    "type": "productivelib:ingredient_modifier",
     "chance": 0.15,
     "addition": [{
         "item": "mysticalagriculture:cognizant_dust"

--- a/kubejs/data/modpack/loot_modifiers/turtle_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/turtle_wannabee.json
@@ -9,7 +9,7 @@
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],
-    "type": "productivebees:ingredient_modifier",
+    "type": "productivelib:ingredient_modifier",
     "chance": 0.25,
     "addition": {
         "item": "minecraft:turtle_egg"

--- a/kubejs/data/modpack/loot_modifiers/turtle_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/turtle_wannabee.json
@@ -1,0 +1,17 @@
+{
+    "conditions": [
+      {
+        "condition": "forge:loot_table_id",
+        "loot_table_id": "minecraft:entities/turtle"
+      },
+      {
+        "condition": "productivebees:killed_by_uuid",
+        "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
+      }
+    ],
+    "type": "productivebees:ingredient_modifier",
+    "chance": 0.25,
+    "addition": {
+        "item": "minecraft:turtle_egg"
+    }
+  }

--- a/kubejs/data/modpack/loot_modifiers/turtle_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/turtle_wannabee.json
@@ -5,7 +5,7 @@
         "loot_table_id": "minecraft:entities/turtle"
       },
       {
-        "condition": "productivebees:killed_by_uuid",
+        "condition": "productivelib:killed_by_uuid",
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],

--- a/kubejs/data/modpack/loot_modifiers/warden_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/warden_drygmy.json
@@ -9,7 +9,7 @@
         "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
       }
     ],
-    "type": "productivebees:ingredient_modifier",
+    "type": "productivelib:ingredient_modifier",
     "chance": 0.5,
     "addition": {
         "item": "bhc:blue_heart"

--- a/kubejs/data/modpack/loot_modifiers/warden_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/warden_drygmy.json
@@ -1,0 +1,17 @@
+{
+    "conditions": [
+      {
+        "condition": "forge:loot_table_id",
+        "loot_table_id": "minecraft:entities/warden"
+      },
+      {
+        "condition": "productivebees:killed_by_uuid",
+        "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
+      }
+    ],
+    "type": "productivebees:ingredient_modifier",
+    "chance": 0.5,
+    "addition": {
+        "item": "bhc:blue_heart"
+    }
+  }

--- a/kubejs/data/modpack/loot_modifiers/warden_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/warden_drygmy.json
@@ -5,7 +5,7 @@
         "loot_table_id": "minecraft:entities/warden"
       },
       {
-        "condition": "productivebees:killed_by_uuid",
+        "condition": "productivelib:killed_by_uuid",
         "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
       }
     ],

--- a/kubejs/data/modpack/loot_modifiers/warden_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/warden_wannabee.json
@@ -9,7 +9,7 @@
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],
-    "type": "productivebees:ingredient_modifier",
+    "type": "productivelib:ingredient_modifier",
     "chance": 0.5,
     "addition": {
         "item": "bhc:blue_heart"

--- a/kubejs/data/modpack/loot_modifiers/warden_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/warden_wannabee.json
@@ -5,7 +5,7 @@
         "loot_table_id": "minecraft:entities/warden"
       },
       {
-        "condition": "productivebees:killed_by_uuid",
+        "condition": "productivelib:killed_by_uuid",
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],

--- a/kubejs/data/modpack/loot_modifiers/warden_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/warden_wannabee.json
@@ -1,0 +1,17 @@
+{
+    "conditions": [
+      {
+        "condition": "forge:loot_table_id",
+        "loot_table_id": "minecraft:entities/warden"
+      },
+      {
+        "condition": "productivebees:killed_by_uuid",
+        "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
+      }
+    ],
+    "type": "productivebees:ingredient_modifier",
+    "chance": 0.5,
+    "addition": {
+        "item": "bhc:blue_heart"
+    }
+  }

--- a/kubejs/data/modpack/loot_modifiers/wilden_chimera_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/wilden_chimera_drygmy.json
@@ -5,7 +5,7 @@
         "loot_table_id": "ars_nouveau:entities/wilden_boss"
       },
       {
-        "condition": "productivebees:killed_by_uuid",
+        "condition": "productivelib:killed_by_uuid",
         "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
       }
     ],

--- a/kubejs/data/modpack/loot_modifiers/wilden_chimera_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/wilden_chimera_drygmy.json
@@ -1,0 +1,26 @@
+{
+    "conditions": [
+      {
+        "condition": "forge:loot_table_id",
+        "loot_table_id": "ars_nouveau:entities/wilden_boss"
+      },
+      {
+        "condition": "productivebees:killed_by_uuid",
+        "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
+      }
+    ],
+    "type": "productivebees:ingredient_modifier",
+    "chance": 0.05,
+    "addition": [{
+        "item": "ars_nouveau:wilden_tribute"
+    },
+    {
+        "item": "ars_nouveau:wilden_horn"
+    },
+    {
+        "item": "ars_nouveau:wilden_spike"
+    },
+    {
+        "item": "ars_nouveau:wilden_wing"
+    }]
+  }

--- a/kubejs/data/modpack/loot_modifiers/wilden_chimera_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/wilden_chimera_drygmy.json
@@ -9,7 +9,7 @@
         "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
       }
     ],
-    "type": "productivebees:ingredient_modifier",
+    "type": "productivelib:ingredient_modifier",
     "chance": 0.05,
     "addition": [{
         "item": "ars_nouveau:wilden_tribute"

--- a/kubejs/data/modpack/loot_modifiers/wilden_chimera_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/wilden_chimera_wannabee.json
@@ -9,7 +9,7 @@
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],
-    "type": "productivebees:ingredient_modifier",
+    "type": "productivelib:ingredient_modifier",
     "chance": 0.05,
     "addition": [{
         "item": "ars_nouveau:wilden_tribute"

--- a/kubejs/data/modpack/loot_modifiers/wilden_chimera_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/wilden_chimera_wannabee.json
@@ -1,0 +1,26 @@
+{
+    "conditions": [
+      {
+        "condition": "forge:loot_table_id",
+        "loot_table_id": "ars_nouveau:entities/wilden_boss"
+      },
+      {
+        "condition": "productivebees:killed_by_uuid",
+        "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
+      }
+    ],
+    "type": "productivebees:ingredient_modifier",
+    "chance": 0.05,
+    "addition": [{
+        "item": "ars_nouveau:wilden_tribute"
+    },
+    {
+        "item": "ars_nouveau:wilden_horn"
+    },
+    {
+        "item": "ars_nouveau:wilden_spike"
+    },
+    {
+        "item": "ars_nouveau:wilden_wing"
+    }]
+  }

--- a/kubejs/data/modpack/loot_modifiers/wilden_chimera_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/wilden_chimera_wannabee.json
@@ -5,7 +5,7 @@
         "loot_table_id": "ars_nouveau:entities/wilden_boss"
       },
       {
-        "condition": "productivebees:killed_by_uuid",
+        "condition": "productivelib:killed_by_uuid",
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],

--- a/kubejs/data/modpack/loot_modifiers/wither_bhc_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/wither_bhc_wannabee.json
@@ -5,7 +5,7 @@
         "loot_table_id": "minecraft:entities/wither"
       },
       {
-        "condition": "productivebees:killed_by_uuid",
+        "condition": "productivelib:killed_by_uuid",
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],

--- a/kubejs/data/modpack/loot_modifiers/wither_bhc_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/wither_bhc_wannabee.json
@@ -9,7 +9,7 @@
         "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
       }
     ],
-    "type": "productivebees:ingredient_modifier",
+    "type": "productivelib:ingredient_modifier",
     "chance": 0.15,
     "addition": {
         "item": "bhc:yellow_heart"

--- a/kubejs/data/modpack/loot_modifiers/wither_bhc_wannabee.json
+++ b/kubejs/data/modpack/loot_modifiers/wither_bhc_wannabee.json
@@ -1,0 +1,17 @@
+{
+    "conditions": [
+      {
+        "condition": "forge:loot_table_id",
+        "loot_table_id": "minecraft:entities/wither"
+      },
+      {
+        "condition": "productivebees:killed_by_uuid",
+        "uuid": "bf699a99-b67c-35dc-981f-fb67fe089dbd"
+      }
+    ],
+    "type": "productivebees:ingredient_modifier",
+    "chance": 0.15,
+    "addition": {
+        "item": "bhc:yellow_heart"
+    }
+  }

--- a/kubejs/data/modpack/loot_modifiers/wither_nether_star_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/wither_nether_star_drygmy.json
@@ -1,0 +1,20 @@
+{
+    "conditions": [
+      {
+        "condition": "forge:loot_table_id",
+        "loot_table_id": "minecraft:entities/wither"
+      },
+      {
+        "condition": "productivebees:killed_by_uuid",
+        "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
+      }
+    ],
+    "type": "productivebees:ingredient_modifier",
+    "chance": 1,
+    "addition": [{
+        "item": "minecraft:nether_star"
+    },
+    {
+        "item": "bhc:yellow_heart"
+    }]
+  }

--- a/kubejs/data/modpack/loot_modifiers/wither_nether_star_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/wither_nether_star_drygmy.json
@@ -9,7 +9,7 @@
         "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
       }
     ],
-    "type": "productivebees:ingredient_modifier",
+    "type": "productivelib:ingredient_modifier",
     "chance": 1,
     "addition": [{
         "item": "minecraft:nether_star"

--- a/kubejs/data/modpack/loot_modifiers/wither_nether_star_drygmy.json
+++ b/kubejs/data/modpack/loot_modifiers/wither_nether_star_drygmy.json
@@ -5,7 +5,7 @@
         "loot_table_id": "minecraft:entities/wither"
       },
       {
-        "condition": "productivebees:killed_by_uuid",
+        "condition": "productivelib:killed_by_uuid",
         "uuid": "7400926d-1007-4e53-880f-b43e67f2bf29"
       }
     ],

--- a/kubejs/server_scripts/mods/mysticalagriculture/crafting.js
+++ b/kubejs/server_scripts/mods/mysticalagriculture/crafting.js
@@ -102,6 +102,11 @@ ServerEvents.recipes(event => {
     energy: 400
   })
 
+  // add recipe to make turtle eggs from turtle essence
+  event.shaped('4x minecraft:turtle_egg', ['   ', '   ', 'EEE'], {
+    E: 'mysticalagriculture:turtle_essence'
+  }).id('kubejs:mysticalagriculture/turtle_egg')
+
   // remove gaia crux
   event.remove({ id: "mysticalagradditions:gaia_spirit_crux" })
 })


### PR DESCRIPTION
Adds to the drop pool for ender dragons (15% chance for wannabee, 50% for drygmy)
- Cognizant dust
- Dragon tooth
- Dragon egg
- Dragon head
- Dragon scale (Mystical Agradditions)
- Dragon leg
- Dragon scale (Quark)
- Green heart

Adds to the drop pool for Wilden Chimera (5% chance for wannabee and drygmy)
- Wilden tribute
- Wilden horn
- Wilden spike
- Wilden wing

Adds to the drop pool for Warden (50% chance for both)
- Blue heart

Adds to the drop pool for Wither (15% chance for wannabee, 50% for drygmy)
- Yellow heart
- Nether star (added to drygmy, already present for wannabee)

Adds to the drop pool for Chicken (25% chance for wannabee, 0% for drygmy)
- Egg

Adds to the drop pool for Turtle (25% chance for wannabee, 0% for drygmy)
- Turtle egg

Lastly, adds a recipe to craft turtle eggs from turtle essence in Mystical Agriculture

Since the drygmy has a limit on how much loot it can output at once, it felt reasonable to give it a higher chance for most of the loot changes. This also only affects the drops acquired by the wannabee and drygmy, players should see no change to manual mob hunting.