### PR TITLE
Fix MUO recipe tiers to UV

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
@@ -78,7 +78,7 @@ ServerEvents.recipes(event => {
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:nether_star', 144 * 16)])
         .itemOutputs(['288x gtceu:neutronium_ingot', '126x allthemodium:allthemodium_ingot', '126x allthemodium:unobtainium_ingot', '126x gtceu:naquadria_ingot'])
         .outputFluids([Fluid.of('gtceu:samarium', 12960), Fluid.of('gtceu:darmstadtium', 4608)])
-        .duration(1200).EUt(UHV * 9)
+        .duration(1200 * 36).EUt(UV)
 
     event.recipes.gtceu.micro_universe_collector('end_ore')
         .notConsumable('16x kubejs:micro_universe_catalyst')
@@ -86,7 +86,7 @@ ServerEvents.recipes(event => {
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:ender_air', 1000000), Fluid.of('gtceu:nether_star', 144 * 64)])
         .itemOutputs(['8192x gtceu:endstone_naquadah_ore', '8192x gtceu:endstone_trinium_ore', '512x gtceu:endstone_plutonium_ore', '8192x gtceu:endstone_tungstate_ore'])
         .outputFluids([Fluid.of('gtceu:liquid_ender_air', 640000), Fluid.of('gtceu:tritium', 32000)])
-        .duration(1800).EUt(UHV * 9)
+        .duration(1800 * 36).EUt(UV)
 
     event.recipes.gtceu.micro_universe_collector('nether_ore')
         .notConsumable('16x kubejs:micro_universe_catalyst')
@@ -94,7 +94,7 @@ ServerEvents.recipes(event => {
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:nether_air', 1000000), Fluid.of('gtceu:nether_star', 144 * 16)])
         .itemOutputs(['8192x gtceu:netherrack_sulfur_ore', '8192x gtceu:netherrack_tetrahedrite_ore', '4096x gtceu:netherrack_sphalerite_ore'])
         .outputFluids([Fluid.of('gtceu:liquid_nether_air', 640000), Fluid.of('minecraft:lava', 100000), Fluid.of('gtceu:inert_nether_essence', 16000)])
-        .duration(1200).EUt(UHV * 3)
+        .duration(1200 * 12).EUt(UV)
 
     event.recipes.gtceu.micro_universe_collector('overworld_ore')
         .notConsumable('16x kubejs:micro_universe_catalyst')
@@ -102,19 +102,19 @@ ServerEvents.recipes(event => {
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:air', 1000000), Fluid.of('gtceu:nether_star', 144 * 16)])
         .itemOutputs(['8192x gtceu:redstone_ore', '4096x gtceu:tantalite_ore', '8192x gtceu:salt_ore', '4096x gtceu:galena_ore', '4096x gtceu:cobaltite_ore'])
         .outputFluids([Fluid.of('gtceu:liquid_air', 640000), Fluid.of('gtceu:oil', 1000000)])
-        .duration(1200).EUt(UHV * 1)
+        .duration(1200 * 4).EUt(UV)
     
     event.recipes.gtceu.micro_universe_collector('max_energy_hatch')
         .itemInputs(['1x allthetweaks:greg_star_block', '8x gtceu:uhv_energy_input_hatch_16a', '1x kubejs:micro_universe_drill_ship', '16x kubejs:micro_universe_catalyst'])
         .inputFluids([Fluid.of('gtceu:star_matter_plasma', 12000), Fluid.of('gtceu:nether_star', 1574640)])
         .itemOutputs(['1x gtceu:max_energy_input_hatch'])
-        .duration(2400).EUt(UHV * 36)
+        .duration(2400 * 144).EUt(UV)
     
     event.recipes.gtceu.micro_universe_collector('creative_energy')
         .itemInputs(['1x allthetweaks:greg_star_block', '32x gtceu:uhv_16a_energy_converter', '1x kubejs:micro_universe_drill_ship', '16x kubejs:micro_universe_catalyst'])
         .inputFluids([Fluid.of('gtceu:nether_star', 1574640)])
         .itemOutputs(['1x gtceu:creative_energy'])
-        .duration(2400).EUt(UHV * 36)
+        .duration(2400 * 144).EUt(UV)
 
 
     // Energy Generation
@@ -122,11 +122,11 @@ ServerEvents.recipes(event => {
         .notConsumable('16x kubejs:micro_universe_catalyst')
         .itemInputs(['1x kubejs:micro_universe_drill_ship', '256x gtceu:naquadria_ingot', '128x gtceu:neutronium_ingot', '1x #gtceu:batteries/uv'])
         .inputFluids(Fluid.of('gtceu:nether_star', 144 * 16))
-        .duration(18000).EUt(-(GTValues.V[GTValues.UEV] * 16))
+        .duration(18000 * 256).EUt(-(GTValues.V[GTValues.UV]))
 
     event.recipes.gtceu.micro_universe_reactor('uev_power')
         .notConsumable('16x kubejs:micro_universe_catalyst')
         .itemInputs(['1x kubejs:micro_universe_drill_ship', '256x gtceu:tritanium_ingot', '128x gtceu:neutronium_ingot', '1x #gtceu:batteries/uhv'])
         .inputFluids(Fluid.of('gtceu:nether_star', 144 * 16))
-        .duration(18000).EUt(-(GTValues.V[GTValues.UIV] * 16))
+        .duration(18000 * 1024).EUt(-(GTValues.V[GTValues.UV]))
 })

--- a/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/micro_universe_orb_recipes.js
@@ -78,7 +78,7 @@ ServerEvents.recipes(event => {
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:nether_star', 144 * 16)])
         .itemOutputs(['288x gtceu:neutronium_ingot', '126x allthemodium:allthemodium_ingot', '126x allthemodium:unobtainium_ingot', '126x gtceu:naquadria_ingot'])
         .outputFluids([Fluid.of('gtceu:samarium', 12960), Fluid.of('gtceu:darmstadtium', 4608)])
-        .duration(1200 * 36).EUt(UV)
+        .duration(1200 * 8).EUt(UV)
 
     event.recipes.gtceu.micro_universe_collector('end_ore')
         .notConsumable('16x kubejs:micro_universe_catalyst')
@@ -86,7 +86,7 @@ ServerEvents.recipes(event => {
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:ender_air', 1000000), Fluid.of('gtceu:nether_star', 144 * 64)])
         .itemOutputs(['8192x gtceu:endstone_naquadah_ore', '8192x gtceu:endstone_trinium_ore', '512x gtceu:endstone_plutonium_ore', '8192x gtceu:endstone_tungstate_ore'])
         .outputFluids([Fluid.of('gtceu:liquid_ender_air', 640000), Fluid.of('gtceu:tritium', 32000)])
-        .duration(1800 * 36).EUt(UV)
+        .duration(1800 * 8).EUt(UV)
 
     event.recipes.gtceu.micro_universe_collector('nether_ore')
         .notConsumable('16x kubejs:micro_universe_catalyst')
@@ -94,7 +94,7 @@ ServerEvents.recipes(event => {
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:nether_air', 1000000), Fluid.of('gtceu:nether_star', 144 * 16)])
         .itemOutputs(['8192x gtceu:netherrack_sulfur_ore', '8192x gtceu:netherrack_tetrahedrite_ore', '4096x gtceu:netherrack_sphalerite_ore'])
         .outputFluids([Fluid.of('gtceu:liquid_nether_air', 640000), Fluid.of('minecraft:lava', 100000), Fluid.of('gtceu:inert_nether_essence', 16000)])
-        .duration(1200 * 12).EUt(UV)
+        .duration(1200 * 4).EUt(UV)
 
     event.recipes.gtceu.micro_universe_collector('overworld_ore')
         .notConsumable('16x kubejs:micro_universe_catalyst')
@@ -102,19 +102,19 @@ ServerEvents.recipes(event => {
         .inputFluids([Fluid.of('gtceu:rocket_fuel', 10000), Fluid.of('gtceu:air', 1000000), Fluid.of('gtceu:nether_star', 144 * 16)])
         .itemOutputs(['8192x gtceu:redstone_ore', '4096x gtceu:tantalite_ore', '8192x gtceu:salt_ore', '4096x gtceu:galena_ore', '4096x gtceu:cobaltite_ore'])
         .outputFluids([Fluid.of('gtceu:liquid_air', 640000), Fluid.of('gtceu:oil', 1000000)])
-        .duration(1200 * 4).EUt(UV)
+        .duration(1200 * 2).EUt(UV)
     
     event.recipes.gtceu.micro_universe_collector('max_energy_hatch')
         .itemInputs(['1x allthetweaks:greg_star_block', '8x gtceu:uhv_energy_input_hatch_16a', '1x kubejs:micro_universe_drill_ship', '16x kubejs:micro_universe_catalyst'])
         .inputFluids([Fluid.of('gtceu:star_matter_plasma', 12000), Fluid.of('gtceu:nether_star', 1574640)])
         .itemOutputs(['1x gtceu:max_energy_input_hatch'])
-        .duration(2400 * 144).EUt(UV)
+        .duration(2400 * 16).EUt(UV)
     
     event.recipes.gtceu.micro_universe_collector('creative_energy')
         .itemInputs(['1x allthetweaks:greg_star_block', '32x gtceu:uhv_16a_energy_converter', '1x kubejs:micro_universe_drill_ship', '16x kubejs:micro_universe_catalyst'])
         .inputFluids([Fluid.of('gtceu:nether_star', 1574640)])
         .itemOutputs(['1x gtceu:creative_energy'])
-        .duration(2400 * 144).EUt(UV)
+        .duration(2400 * 16).EUt(UV)
 
 
     // Energy Generation


### PR DESCRIPTION
Allows the MUO recipes to work again

A prior GT update changed how energy hatches and overclocking works to not allow recipe tier overclocks from a single energy hatch, and to only allow a single recipe tier overclock with multiple energy hatches. 

This affected the MUO because the highest tier hatch it can accept is a 4096A UV Laser Target Hatch, which while it provides the equivalent of 1A of MAX energy, it is still at just a UV recipe tier. 

4096A of UV will process recipes at a much faster rate (64x as fast with a non-perfect overclock) than if it was just 2A of UV, but it is important to note that the recipe tier is still locked at UV with only one energy input hatch or UHV with two energy input hatches. 