### PR TITLE
Adjust Comb Processor recipe duration

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/apiary_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/apiary_recipes.js
@@ -333,7 +333,7 @@ ServerEvents.recipes(event => {
     // copy all centrifuge recipes
     event.forEachRecipe({type: 'productivebees:centrifuge'}, rawRecipe => {
         let recipe = JSON.parse(rawRecipe.json)
-        let duration = 300 // default centrifuge processing time in ticks = 300
+        let duration = 300 / 9 // default centrifuge processing time in ticks = 300, heated centrifuge is 9 times faster
         let inputObj = recipe.ingredient // ingredient should always exist
         let input
         let inputBlock


### PR DESCRIPTION
The Comb Processor base recipe duration was set to the base processing speed of a Productive Bees Centrifuge despite requiring a Productive Bees Heated Centrifuge to make it. 

This changes the base recipe duration of the Comb Processor to match the processing speed of a Heated Centrifuge with no speed upgrades.