### PR TITLE
Reduce NaN crafting time

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/gtceu.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceu.js
@@ -1,4 +1,13 @@
 ServerEvents.recipes(event => {
+
+	event.remove({ id: 'gtceu:extruder/nan_certificate' })
+
+    event.recipes.gtceu.extruder('nan_certificate_modified')
+        .itemInputs(['64x gtceu:neutronium_block', '64x gtceu:neutronium_block'])
+        .itemOutputs('gtceu:nan_certificate')
+        .duration(16400)
+        .EUt(UHV)
+
     event.recipes.gtceu.chemical_bath('kubejs:inert_star')
         .itemInputs('minecraft:wither_skeleton_skull')
         .inputFluids(Fluid.of('gtceu:polyethylene', 1000))


### PR DESCRIPTION
Since the Large Extrusion Machine no longer has a perfect overclock, crafting the Certificate of Not a Noob Anymore takes approximately 58 hours and 15 minutes at UEV. This isn't good for us because it is a crafting component of the Gregstar. 

The proposed change here reduces the duration to be 820 seconds at UHV or 410 seconds at UEV, which is closer to where it was when the machine had a perfect overclock.

This change does mean it now requires building a Large Extrusion Machine to achieve the UHV+ voltages necessary.