### PR TITLE
Fix Creative Jetpack Recipe

### DIFF
--- a/kubejs/server_scripts/modpack/atm_star_creative.js
+++ b/kubejs/server_scripts/modpack/atm_star_creative.js
@@ -162,7 +162,7 @@ ServerEvents.recipes(allthemods => {
     C: Item.of('ironjetpacks:capacitor', { Id: "ironjetpacks:creative" }).strongNBT(),
     D: Item.of('ironjetpacks:thruster', { Id: "ironjetpacks:creative" }).strongNBT(),
     E: 'allthetweaks:atm_star',
-    F: Item.of('ironjetpacks:jetpack', { Id: "ironjetpacks:unobtainium" }).strongNBT()
+    F: Item.of('ironjetpacks:jetpack', { Id: "ironjetpacks:unobtainium" }).weakNBT()
   }).id('allthemods:ironjetpacks_creative_jetpack')
 
   ///#Mekanism


### PR DESCRIPTION
On my server, my players were having issues crafting this jetpack. This fixes the issue with the unobtainium jetpack having NBT data that strongNBT isn't matching in the recipe for the creative jetpack. Basically, if the jetpack has NBT other than the ID, it won't be valid. Switching it to weak will allow to only need the NBT of ID.