### PR TITLE
Fix: Draconic Evolution Ender Dragon loot Missing in Hostile Neural Networks & Missing Crushing Recipe (ingot -> dust)

### DIFF
--- a/kubejs/data/hostilenetworks/data_models/ender_dragon.json
+++ b/kubejs/data/hostilenetworks/data_models/ender_dragon.json
@@ -35,6 +35,10 @@
         {
             "item": "ends_delight:dragon_leg",
             "count": 4
+        },
+        {
+            "item": "draconicevolution:dragon_heart",
+            "count": 1
         }
     ],
     "data_per_kill": [

--- a/kubejs/server_scripts/mods/draconic_evo/draconic_evo.js
+++ b/kubejs/server_scripts/mods/draconic_evo/draconic_evo.js
@@ -40,6 +40,47 @@ ServerEvents.recipes(allthemods =>{
         input: {ingredient: {item: 'draconicevolution:awakened_draconium_ingot'}},
         output: {item: 'draconicevolution:awakened_draconium_dust'}
     }).id(`allthemods:mekanism/crushing/awakened_draconium_dust`)
+
+    allthemods.custom({
+        type: 'create:crushing',
+        ingredients: [{item: 'draconicevolution:draconium_ingot'}],
+        processingTime: 300,
+        results: [
+          {item: 'draconicevolution:draconium_dust'}
+        ]
+    }).id(`allthemods:create/crushing/draconium_dust`)
+
+    allthemods.custom({
+        type: 'thermal:pulverizer',
+        ingredient: {item: 'draconicevolution:draconium_ingot'},
+        result: [
+            {item: 'draconicevolution:draconium_dust'}
+        ],
+        experience: 0.1
+    }).id(`allthemods:thermal/pulverizing/draconium_dust`)
+
+    allthemods.custom({
+        type: "occultism:crushing",
+        ingredient: {item: 'draconicevolution:draconium_ingot'},
+        result: {item: 'draconicevolution:draconium_dust'},
+        crushing_time: 200,
+        ignore_crushing_multiplier: true
+    }).id(`allthemods:occultism/crushing/draconium_dust`)
+
+    allthemods.custom({
+        type: 'immersiveengineering:crusher',
+        energy: 3200,
+        input: {item: 'draconicevolution:draconium_ingot'},
+        result: {count: 1,item: 'draconicevolution:draconium_dust'},
+        secondaries: []
+    }).id(`allthemods:immersive/crushing/draconium_dust`)
+
+    allthemods.custom({
+        type: 'mekanism:crushing',
+        input: {ingredient: {item: 'draconicevolution:draconium_ingot'}},
+        output: {item: 'draconicevolution:draconium_dust'}
+    }).id(`allthemods:mekanism/crushing/draconium_dust`)
+
 })
 
 // This File has been authored by AllTheMods Staff (me, Mitchell52) for use in AllTheMods - AllTheMods 9.


### PR DESCRIPTION
With the recent addition of Draconic Evolution i ran into a few Problems:

1. Ender Dragon Loot "Dragon Heart" (added by Draconic Evolution) wasn't available in Hostile Neural Networks 
_This Item is needed to Craft (via Fusion crafting) Awakened Draconium Block (so automation would be wise)_

2. There was no way to convert Draconium Ingot back into Dust
_If you gather Draconic Dust by mining the Ore this wouldn't be an issue, but when Automating with Mystical Agriculture, you're only able to get Draconium Ingots - there are a few recipes that require Dust;  so you wouldn't be able to fully automate it._



Thanks for the great work :+1: