### PR TITLE
Reenabling custom observing quests

### DIFF
--- a/kubejs/client_scripts/observeGT.js
+++ b/kubejs/client_scripts/observeGT.js
@@ -40,13 +40,13 @@ ClientEvents.tick(allthemods => {
 })
 
 NetworkEvents.dataReceived('customTask', allthemods => {
-    //const {entity, data, level} = event
-    //let taskString = data.task
-    //let task = FTBQuests.getObject(level, taskString)
-    //let playerQuestData = FTBQuests.getData(entity)
-    //if (task && playerQuestData && !playerQuestData.isCompleted(task) && playerQuestData.canStartTasks(task.quest)) {
-    //    playerQuestData.addProgress(task, 1)
-    //}
+    const {entity, data, level} = event
+    let taskString = data.task
+    let task = FTBQuests.getObject(level, taskString)
+    let playerQuestData = FTBQuests.getData(entity)
+    if (task && playerQuestData && !playerQuestData.isCompleted(task) && playerQuestData.canStartTasks(task.quest)) {
+        playerQuestData.addProgress(task, 1)
+    }
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.

--- a/kubejs/client_scripts/observeMekanism.js
+++ b/kubejs/client_scripts/observeMekanism.js
@@ -69,13 +69,13 @@ ClientEvents.tick(allthemods => {
 })
 
 NetworkEvents.dataReceived('customTask', allthemods => {
-    //const {entity, data, level} = event
-    //let taskString = data.task
-    //let task = FTBQuests.getObject(level, taskString)
-    //let playerQuestData = FTBQuests.getData(entity)
-    //if (task && playerQuestData && !playerQuestData.isCompleted(task) && playerQuestData.canStartTasks(task.quest)) {
-    //    playerQuestData.addProgress(task, 1)
-    //}
+    const {entity, data, level} = event
+    let taskString = data.task
+    let task = FTBQuests.getObject(level, taskString)
+    let playerQuestData = FTBQuests.getData(entity)
+    if (task && playerQuestData && !playerQuestData.isCompleted(task) && playerQuestData.canStartTasks(task.quest)) {
+        playerQuestData.addProgress(task, 1)
+    }
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.

--- a/kubejs/server_scripts/mods/ftbquests/customTask.js
+++ b/kubejs/server_scripts/mods/ftbquests/customTask.js
@@ -1,7 +1,16 @@
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
-// ELEMENT REMOVED
+//Renabled Custom Task for observing in quests.
+NetworkEvents.dataReceived('customTask', event => {
+	const {entity, data, level} = event
+    let taskString = data.task
+    let task = FTBQuests.getObject(level, taskString)
+    let playerQuestData = FTBQuests.getData(entity)
+    if (task && playerQuestData && !playerQuestData.isCompleted(task) && playerQuestData.canStartTasks(task.quest)) {
+        playerQuestData.addProgress(task, 1)
+    }
+})
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
This should re-enable quests like the cleanroom from GT and the mekanism multiblock observing