### PR TITLE
NaN bee changed name

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/apiary_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/apiary_recipes.js
@@ -37,7 +37,7 @@ ServerEvents.recipes(allthemods => {
         } else if (inputString == 'spacial') {
             returnString = 'Spatial Bee'
         } else if (inputString == 'neutronium') {
-            returnString = 'Not a Neutronium Bee'
+            returnString = 'Neutronium Bee'
         } else if (inputString == 'soul_shard') {
             returnString = 'Soul Bee'
         } else if (inputString == 'prosperity') {


### PR DESCRIPTION
Looks like the Not a Neutronium Bee has that name as an entity in the world but when caged it is set to Neutronium Bee.

This fixes the naming so NaN bee works in the Apiary again.