### PR TITLE
Remove bee name requirement from Apiary recipes

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/apiary_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/apiary_recipes.js
@@ -182,8 +182,10 @@ ServerEvents.recipes(allthemods => {
                 input = Item.of('productivebees:bee_cage', '{name: "Bee", entity: "minecraft:bee"}')
                 input_ii = input.copy()
             } else {
-                input = Item.of('productivebees:bee_cage', 1, '{type:"' + recipe.ingredient + '", entity: "productivebees:configurable_bee", name: "' + makeName(beeType) +'"}')
-                input_ii = Item.of('productivebees:bee_cage', 1, goodBeeGenes + 'type:"' + recipe.ingredient + '", entity: "productivebees:configurable_bee", name: "' + makeName(beeType) +'"}')
+                // input = Item.of('productivebees:bee_cage', 1, '{type:"' + recipe.ingredient + '", entity: "productivebees:configurable_bee", name: "' + makeName(beeType) +'"}')
+                // input_ii = Item.of('productivebees:bee_cage', 1, goodBeeGenes + 'type:"' + recipe.ingredient + '", entity: "productivebees:configurable_bee", name: "' + makeName(beeType) +'"}')
+                input = Item.of('productivebees:bee_cage', 1, '{type:"' + recipe.ingredient + '", entity: "productivebees:configurable_bee"}')
+                input_ii = Item.of('productivebees:bee_cage', 1, goodBeeGenes + 'type:"' + recipe.ingredient + '", entity: "productivebees:configurable_bee"}')
             }
             let results = recipe.results // array of objects like { item: { }, chance: 40 }
             let flower


### PR DESCRIPTION
This change makes the Apiary recipes in JEI read as if the caged bee(s) have no name. This is a good thing because it now allows for the bee to have any name! 

You could now name all your bees `George` with name tags for example, and the Apiary MK I and Apiary MK II would both still function with those bees just fine, assuming they have the requisite genes and are the correct entity with the correct flower.