### PR TITLE
Fix naq ore, add AAE-GT compat, add new universal presses

### DIFF
--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -466,7 +466,7 @@ tools:
 gameplay:
   # Enable hazardous materials
   # Default: true
-  hazardsEnabled: true
+  hazardsEnabled: false
 
   # Whether hazards are applied to all valid items, or just GT's.
   # true = all, false = GT only.

--- a/kubejs/data/ae2/recipes/inscriber/ultimate_universal_accumulation_processor_print.json
+++ b/kubejs/data/ae2/recipes/inscriber/ultimate_universal_accumulation_processor_print.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "tag": "forge:ingots/sky_steel"
+      },
+      "top": {
+        "item": "kubejs:ultimate_universal_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "megacells:printed_accumulation_processor"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/ultimate_universal_calculation_processor_print.json
+++ b/kubejs/data/ae2/recipes/inscriber/ultimate_universal_calculation_processor_print.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "item": "ae2:certus_quartz_crystal"
+      },
+      "top": {
+        "item": "kubejs:ultimate_universal_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "ae2:printed_calculation_processor"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/ultimate_universal_energy_processor_print.json
+++ b/kubejs/data/ae2/recipes/inscriber/ultimate_universal_energy_processor_print.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "item": "appflux:charged_redstone"
+      },
+      "top": {
+        "item": "kubejs:ultimate_universal_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "appflux:printed_energy_processor"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/ultimate_universal_engineering_processor_print.json
+++ b/kubejs/data/ae2/recipes/inscriber/ultimate_universal_engineering_processor_print.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "tag": "forge:gems/diamond"
+      },
+      "top": {
+        "item": "kubejs:ultimate_universal_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "ae2:printed_engineering_processor"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/ultimate_universal_logic_processor_print.json
+++ b/kubejs/data/ae2/recipes/inscriber/ultimate_universal_logic_processor_print.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "tag": "forge:ingots/gold"
+      },
+      "top": {
+        "item": "kubejs:ultimate_universal_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "ae2:printed_logic_processor"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/ultimate_universal_press.json
+++ b/kubejs/data/ae2/recipes/inscriber/ultimate_universal_press.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "item": "allthemodium:vibranium_allthemodium_alloy_block"
+      },
+      "top": {
+        "item": "kubejs:ultimate_universal_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "kubejs:ultimate_universal_press"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/ultimate_universal_quantum_processor_print.json
+++ b/kubejs/data/ae2/recipes/inscriber/ultimate_universal_quantum_processor_print.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "item": "advanced_ae:quantum_alloy"
+      },
+      "top": {
+        "item": "kubejs:ultimate_universal_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "advanced_ae:printed_quantum_processor"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/ultimate_universal_silicon_print.json
+++ b/kubejs/data/ae2/recipes/inscriber/ultimate_universal_silicon_print.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "tag": "forge:silicon"
+      },
+      "top": {
+        "item": "kubejs:ultimate_universal_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "ae2:printed_silicon"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/universal_addon_accumulation_processor_print.json
+++ b/kubejs/data/ae2/recipes/inscriber/universal_addon_accumulation_processor_print.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "tag": "forge:ingots/sky_steel"
+      },
+      "top": {
+        "item": "kubejs:universal_addon_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "megacells:printed_accumulation_processor"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/universal_addon_energy_processor_print.json
+++ b/kubejs/data/ae2/recipes/inscriber/universal_addon_energy_processor_print.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "item": "appflux:charged_redstone"
+      },
+      "top": {
+        "item": "kubejs:universal_addon_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "appflux:printed_energy_processor"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/universal_addon_press.json
+++ b/kubejs/data/ae2/recipes/inscriber/universal_addon_press.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "item": "minecraft:iron_block"
+      },
+      "top": {
+        "item": "kubejs:universal_addon_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "kubejs:universal_addon_press"
+    }
+  }

--- a/kubejs/data/ae2/recipes/inscriber/universal_addon_quantum_processor_print.json
+++ b/kubejs/data/ae2/recipes/inscriber/universal_addon_quantum_processor_print.json
@@ -1,0 +1,15 @@
+{
+    "type": "ae2:inscriber",
+    "ingredients": {
+      "middle": {
+        "item": "advanced_ae:quantum_alloy"
+      },
+      "top": {
+        "item": "kubejs:universal_addon_press"
+      }
+    },
+    "mode": "inscribe",
+    "result": {
+      "item": "advanced_ae:printed_quantum_processor"
+    }
+  }

--- a/kubejs/server_scripts/mods/ae/recipes.js
+++ b/kubejs/server_scripts/mods/ae/recipes.js
@@ -18,10 +18,29 @@ ServerEvents.recipes(allthemods => {
     L: 'ae2:logic_processor_press',
     E: 'ae2:engineering_processor_press'
   }).id('allthemods:universal_press')
- 
-  allthemods.shapeless(` 4x ae2:fluix_covered_cable`,[`ae2:fluix_covered_dense_cable`]).id(`allthemods:ae2/dense_to_normal`)
-  allthemods.shapeless(` 4x ae2:fluix_smart_cable`,[`ae2:fluix_smart_dense_cable`]).id(`allthemods:ae2/smart_dense_to_smart_normal`)
-  allthemods.shaped('16x ae2:sky_dust', ['DDD','   ','   '] ,{D: 'mysticalagriculture:sky_stone_essence',}).id('allthemods:ae2/skystone_dust')
+
+  allthemods.shaped('kubejs:universal_addon_press', ['FPF', 'CSL', 'FEF'], {
+    F: '#forge:storage_blocks/sky_steel',
+    P: 'megacells:accumulation_processor_press',
+    C: 'appflux:energy_processor_press',
+    S: 'appflux:charged_redstone',
+    L: 'advanced_ae:quantum_processor_press',
+    E: 'advanced_ae:quantum_alloy'
+  }).id('allthemods:universal_addon_press')
+
+  allthemods.shaped('kubejs:ultimate_universal_press', ['FPG', 'CSL', 'GEF'], {
+    F: '#forge:storage_blocks/vibranium_allthemodium_alloy',
+    G: '#forge:storage_blocks/unobtainium_vibranium_alloy',
+    P: 'kubejs:universal_press',
+    C: 'appflux:core_256k',
+    S: 'advanced_ae:quantum_core',
+    L: 'megacells:bulk_cell_component',
+    E: 'kubejs:universal_addon_press'
+  }).id('allthemods:ultimate_universal_press')
+
+  allthemods.shapeless(` 4x ae2:fluix_covered_cable`, [`ae2:fluix_covered_dense_cable`]).id(`allthemods:ae2/dense_to_normal`)
+  allthemods.shapeless(` 4x ae2:fluix_smart_cable`, [`ae2:fluix_smart_dense_cable`]).id(`allthemods:ae2/smart_dense_to_smart_normal`)
+  allthemods.shaped('16x ae2:sky_dust', ['DDD', '   ', '   '], { D: 'mysticalagriculture:sky_stone_essence', }).id('allthemods:ae2/skystone_dust')
 
 })
 

--- a/kubejs/server_scripts/mods/gtceu/apiary_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/apiary_recipes.js
@@ -381,6 +381,9 @@ ServerEvents.recipes(allthemods => {
             // set chance and count if applicable
             if (output.hasOwnProperty('chance')) {
                 chance = output.chance * 100 // convert to base 10000 for GT
+                // boost chance a bit, a little reward for making the comb processor
+                // either +1.25% chance or 1.25 * chance, whichever is higher, up to 10000
+                chance = Math.min(Math.max(chance * 1.25, chance + 125), 10000)
             }
             if (output.hasOwnProperty('max')) {
                 count = output.max // max roll! woo!
@@ -436,7 +439,10 @@ ServerEvents.recipes(allthemods => {
                 if (output.item.hasOwnProperty('tag')) {
                     if (chance != 10000) {
                         combRecipeBuilder.chancedOutput(IngredientHelper.tag(output.item.tag).withCount(count), chance, 0)
-                        combBlockRecipeBuilder.chancedOutput(IngredientHelper.tag(output.item.tag).withCount(count * 4), chance, 0)
+                        combBlockRecipeBuilder.chancedOutput(IngredientHelper.tag(output.item.tag).withCount(count), chance, 0)
+                        combBlockRecipeBuilder.chancedOutput(IngredientHelper.tag(output.item.tag).withCount(count), chance, 0)
+                        combBlockRecipeBuilder.chancedOutput(IngredientHelper.tag(output.item.tag).withCount(count), chance, 0)
+                        combBlockRecipeBuilder.chancedOutput(IngredientHelper.tag(output.item.tag).withCount(count), chance, 0)
                     } else {
                         combRecipeBuilder.itemOutputs(IngredientHelper.tag(output.item.tag).withCount(count))
                         if (output.item.tag != 'forge:wax') {
@@ -448,7 +454,10 @@ ServerEvents.recipes(allthemods => {
                     // console.log("output item item is " + output.item.item)
                     if (chance != 10000) {
                         combRecipeBuilder.chancedOutput(Item.of(output.item.item, count), chance, 0)
-                        combBlockRecipeBuilder.chancedOutput(Item.of(output.item.item, count * 4), chance, 0)
+                        combBlockRecipeBuilder.chancedOutput(Item.of(output.item.item, count), chance, 0)
+                        combBlockRecipeBuilder.chancedOutput(Item.of(output.item.item, count), chance, 0)
+                        combBlockRecipeBuilder.chancedOutput(Item.of(output.item.item, count), chance, 0)
+                        combBlockRecipeBuilder.chancedOutput(Item.of(output.item.item, count), chance, 0)
                     } else {
                         combRecipeBuilder.itemOutputs(Item.of(output.item.item, count))
                         combBlockRecipeBuilder.itemOutputs(Item.of(output.item.item, count * 4))

--- a/kubejs/server_scripts/mods/gtceu/greenhouse_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/greenhouse_recipes.js
@@ -54,7 +54,8 @@ ServerEvents.recipes(allthemods => {
                     recipeBuilder.EUt(MV)
                         .notConsumable(InputItem.of(input))
                         .inputFluids(Fluid.of('minecraft:water', 1000))
-                        .duration(duration * 4)
+                        .duration(duration / 4)
+                        .circuit(0)
                     drops.forEach( (drop) => {
                         if (drop.hasOwnProperty('maxRolls')) {
                             recipeBuilder.chancedOutput(Item.of(drop.output.item, drop.maxRolls), drop.chance * 10000, drop.chance * 10000)
@@ -72,7 +73,8 @@ ServerEvents.recipes(allthemods => {
             recipeBuilder.EUt(MV)
                 .notConsumable(InputItem.of(input))
                 .inputFluids(Fluid.of('minecraft:water', 1000))
-                .duration(duration * 4)
+                .duration(duration / 4)
+                .circuit(0)
             drops.forEach( (drop) => {
                 if (drop.hasOwnProperty('maxRolls')) {
                     recipeBuilder.chancedOutput(Item.of(drop.output.item, drop.maxRolls), drop.chance * 10000, drop.chance * 10000)
@@ -95,7 +97,7 @@ ServerEvents.recipes(allthemods => {
         let inp = 'mysticalagriculture:' + base + '_seeds'
         let out = 'mysticalagriculture:' + base + '_essence'
         let boostOut = '4x mysticalagriculture:' + base + '_essence'
-        let duration = 9600
+        let duration = 9600 / 2
 
         grow(id, inp, out, duration, 'minecraft:air', false)
         grow(id + '_boosted', inp, boostOut, duration, '4x mysticalagriculture:inferium_essence', true)
@@ -106,7 +108,7 @@ ServerEvents.recipes(allthemods => {
         let inp = 'mysticalagriculture:' + base + '_seeds'
         let out = 'mysticalagriculture:' + base + '_essence'
         let boostOut = '4x mysticalagriculture:' + base + '_essence'
-        let duration = 9600
+        let duration = 9600 / 2
 
         grow(id, inp, out, duration, 'minecraft:air', false)
         grow(id + '_boosted', inp, boostOut, duration, '4x mysticalagriculture:prudentium_essence', true)
@@ -126,7 +128,7 @@ ServerEvents.recipes(allthemods => {
         let inp = 'mysticalagriculture:' + base + '_seeds'
         let out = 'mysticalagriculture:' + base + '_essence'
         let boostOut = '4x mysticalagriculture:' + base + '_essence'
-        let duration = 9600 * 2
+        let duration = 9600
 
         grow(id, inp, out, duration, 'minecraft:air', false)
         grow(id + '_boosted', inp, boostOut, duration, '4x mysticalagriculture:tertium_essence', true)
@@ -137,7 +139,7 @@ ServerEvents.recipes(allthemods => {
         let inp = 'mysticalagriculture:' + base + '_seeds'
         let out = 'mysticalagriculture:' + base + '_essence'
         let boostOut = '4x mysticalagriculture:' + base + '_essence'
-        let duration = 9600 * 2
+        let duration = 9600
 
         grow(id, inp, out, duration, 'minecraft:air', false)
         grow(id + '_boosted', inp, boostOut, duration, '4x mysticalagriculture:imperium_essence', true)
@@ -152,7 +154,7 @@ ServerEvents.recipes(allthemods => {
         let inp = 'mysticalagriculture:' + base + '_seeds'
         let out = 'mysticalagriculture:' + base + '_essence'
         let boostOut = '4x mysticalagriculture:' + base + '_essence'
-        let duration = 9600 * 6
+        let duration = 9600 * 3
 
         grow(id, inp, out, duration, 'minecraft:air', false)
         grow(id + '_boosted', inp, boostOut, duration, '4x mysticalagriculture:supremium_essence', true)
@@ -172,7 +174,7 @@ ServerEvents.recipes(allthemods => {
         }
         let out = 'mysticalagriculture:' + base + '_essence'
         let boostOut = '4x mysticalagriculture:' + base + '_essence'
-        let duration = 9600 * 18
+        let duration = 9600 * 9
 
         allthemods.recipes.gtceu.greenhouse(id)
             .circuit(2)
@@ -194,8 +196,8 @@ ServerEvents.recipes(allthemods => {
     })
 
     //////////////// GT Rubber trees ////////////////
-    grow('rubber_sapling', 'gtceu:rubber_sapling', ['32x gtceu:rubber_log', '8x gtceu:sticky_resin', '4x gtceu:rubber_sapling'], 9600.0, 'minecraft:air', false)
-    grow('rubber_sapling_boosted', 'gtceu:rubber_sapling', ['64x gtceu:rubber_log', '16x gtceu:sticky_resin', '4x gtceu:rubber_sapling'], 9600.0, '4x gtceu:fertilizer', true)
+    grow('rubber_sapling', 'gtceu:rubber_sapling', ['32x gtceu:rubber_log', '8x gtceu:sticky_resin', '4x gtceu:rubber_sapling'], 9600.0 / 2, 'minecraft:air', false)
+    grow('rubber_sapling_boosted', 'gtceu:rubber_sapling', ['64x gtceu:rubber_log', '16x gtceu:sticky_resin', '4x gtceu:rubber_sapling'], 9600.0 / 2, '4x gtceu:fertilizer', true)
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.

--- a/kubejs/server_scripts/mods/gtceu/gtceu.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceu.js
@@ -109,6 +109,13 @@ ServerEvents.recipes(allthemods => {
         .duration(80)
         .EUt(LV)
 
+    allthemods.recipes.gtceu.forming_press('ae2/ultimate_universal/printed_logic_circuit')
+        .itemInputs('minecraft:gold_ingot')
+        .notConsumable('kubejs:ultimate_universal_press')
+        .itemOutputs('ae2:printed_logic_processor')
+        .duration(80)
+        .EUt(LV)
+
     allthemods.recipes.gtceu.forming_press('ae2/printed_silicon_circuit')
         .itemInputs('ae2:silicon')
         .notConsumable('ae2:silicon_press')
@@ -119,6 +126,13 @@ ServerEvents.recipes(allthemods => {
     allthemods.recipes.gtceu.forming_press('ae2/universal/printed_silicon_circuit')
         .itemInputs('ae2:silicon')
         .notConsumable('kubejs:universal_press')
+        .itemOutputs('ae2:printed_silicon')
+        .duration(80)
+        .EUt(LV)
+
+    allthemods.recipes.gtceu.forming_press('ae2/ultimate_universal/printed_silicon_circuit')
+        .itemInputs('ae2:silicon')
+        .notConsumable('kubejs:ultimate_universal_press')
         .itemOutputs('ae2:printed_silicon')
         .duration(80)
         .EUt(LV)
@@ -137,6 +151,13 @@ ServerEvents.recipes(allthemods => {
         .duration(80)
         .EUt(LV)
 
+    allthemods.recipes.gtceu.forming_press('ae2/ultimate_universal/printed_engineering_circuit')
+        .itemInputs('minecraft:diamond')
+        .notConsumable('kubejs:ultimate_universal_press')
+        .itemOutputs('ae2:printed_engineering_processor')
+        .duration(80)
+        .EUt(LV)
+
     allthemods.recipes.gtceu.forming_press('ae2/printed_calculation_circuit')
         .itemInputs('ae2:certus_quartz_crystal')
         .notConsumable('ae2:calculation_processor_press')
@@ -151,9 +172,30 @@ ServerEvents.recipes(allthemods => {
         .duration(80)
         .EUt(LV)
 
+    allthemods.recipes.gtceu.forming_press('ae2/ultimate_universal/printed_calculation_circuit')
+        .itemInputs('ae2:certus_quartz_crystal')
+        .notConsumable('kubejs:ultimate_universal_press')
+        .itemOutputs('ae2:printed_calculation_processor')
+        .duration(80)
+        .EUt(LV)
+
     allthemods.recipes.gtceu.forming_press('megacells/printed_accumulation_circuit')
         .itemInputs('megacells:sky_steel_ingot')
         .notConsumable('megacells:accumulation_processor_press')
+        .itemOutputs('megacells:printed_accumulation_processor')
+        .duration(80)
+        .EUt(HV)
+
+    allthemods.recipes.gtceu.forming_press('megacells/universal/printed_accumulation_circuit')
+        .itemInputs('megacells:sky_steel_ingot')
+        .notConsumable('kubejs:universal_addon_press')
+        .itemOutputs('megacells:printed_accumulation_processor')
+        .duration(80)
+        .EUt(HV)
+
+    allthemods.recipes.gtceu.forming_press('megacells/ultimate_universal/printed_accumulation_circuit')
+        .itemInputs('megacells:sky_steel_ingot')
+        .notConsumable('kubejs:ultimate_universal_press')
         .itemOutputs('megacells:printed_accumulation_processor')
         .duration(80)
         .EUt(HV)
@@ -165,12 +207,40 @@ ServerEvents.recipes(allthemods => {
         .duration(80)
         .EUt(MV)
 
+    allthemods.recipes.gtceu.forming_press('appflux/universal/printed_energy_circuit')
+        .itemInputs('appflux:charged_redstone')
+        .notConsumable('kubejs:universal_addon_press')
+        .itemOutputs('appflux:printed_energy_processor')
+        .duration(80)
+        .EUt(MV)
+
+    allthemods.recipes.gtceu.forming_press('appflux/ultimate_universal/printed_energy_circuit')
+        .itemInputs('appflux:charged_redstone')
+        .notConsumable('kubejs:ultimate_universal_press')
+        .itemOutputs('appflux:printed_energy_processor')
+        .duration(80)
+        .EUt(MV)
+
     allthemods.recipes.gtceu.forming_press('aae/printed_quantum_circuit')
         .itemInputs('advanced_ae:quantum_alloy')
         .notConsumable('advanced_ae:quantum_processor_press')
         .itemOutputs('advanced_ae:printed_quantum_processor')
         .duration(80)
-        .EUt(MV)
+        .EUt(HV)
+
+    allthemods.recipes.gtceu.forming_press('aae/universal/printed_quantum_circuit')
+        .itemInputs('advanced_ae:quantum_alloy')
+        .notConsumable('kubejs:universal_addon_press')
+        .itemOutputs('advanced_ae:printed_quantum_processor')
+        .duration(80)
+        .EUt(HV)
+
+    allthemods.recipes.gtceu.forming_press('aae/ultimate_universal/printed_quantum_circuit')
+        .itemInputs('advanced_ae:quantum_alloy')
+        .notConsumable('kubejs:ultimate_universal_press')
+        .itemOutputs('advanced_ae:printed_quantum_processor')
+        .duration(80)
+        .EUt(HV)
 
     // AE2 processors in forming press
     allthemods.recipes.gtceu.forming_press('ae2/logic_circuit')
@@ -207,7 +277,7 @@ ServerEvents.recipes(allthemods => {
         .itemInputs(['advanced_ae:printed_quantum_processor', 'minecraft:redstone', 'ae2:printed_silicon'])
         .itemOutputs('advanced_ae:quantum_processor')
         .duration(80)
-        .EUt(MV)
+        .EUt(HV)
 
     // ATO and vanilla silk touched ore maceration recipes
     // Minecraft stone/deepslate/nether ores

--- a/kubejs/server_scripts/mods/gtceu/gtceu.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceu.js
@@ -3,7 +3,7 @@
 
 ServerEvents.recipes(allthemods => {
 
-	allthemods.remove({ id: 'gtceu:extruder/nan_certificate' })
+    allthemods.remove({ id: 'gtceu:extruder/nan_certificate' })
 
     allthemods.recipes.gtceu.extruder('nan_certificate_modified')
         .itemInputs(['64x gtceu:neutronium_block', '64x gtceu:neutronium_block'])
@@ -17,14 +17,14 @@ ServerEvents.recipes(allthemods => {
         .itemOutputs('kubejs:inert_nether_star')
         .duration(10)
         .EUt(IV)
-    
+
     allthemods.recipes.gtceu.mixer('kubejs:inert_fluid')
         .itemInputs('kubejs:inert_nether_star')
         .inputFluids(Fluid.of('gtceu:aqua_regia', 2000))
         .outputFluids(Fluid.of('gtceu:inert_nether_essence', 2304))
         .duration(12)
         .EUt(IV)
-    
+
     allthemods.recipes.gtceu.autoclave('kubejs:autoclave/nether_star')
         .itemInputs('gtceu:polyethylene_dust')
         .inputFluids(Fluid.of('gtceu:inert_nether_essence', 144))
@@ -67,26 +67,26 @@ ServerEvents.recipes(allthemods => {
         .duration(500)
         .stationResearch(b => b.researchStack(Item.of('gtceu:assembly_line')).CWUt(96).EUt(UV))
         .EUt(ZPM)
-    
-    allthemods.recipes.gtceu.assembler('uhv_16a_energy_hatch')
-        .itemInputs('2x gtceu:uhv_energy_input_hatch_4a', '2x gtceu:uhpic_chip', 'kubejs:superthermal_transference_coil', '2x kubejs:cable_of_hyperconductivity')
-        .itemOutputs('gtceu:uhv_energy_input_hatch_16a')
-        .duration(200)
-        .EUt(UHV)
-    
-    // fluix and sky steel dust maceration
+
+    // fluix, sky steel dust, and shattered singularity maceration
     allthemods.recipes.gtceu.macerator('macerate_fluix')
         .itemInputs('ae2:fluix_crystal')
         .itemOutputs('ae2:fluix_dust')
         .duration(80)
         .EUt(ULV)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_sky_stone')
         .itemInputs('ae2:sky_stone_block')
         .itemOutputs('ae2:sky_dust')
         .duration(80)
         .EUt(ULV)
-    
+
+    allthemods.recipes.gtceu.macerator('macerate_shattered_singularity')
+        .itemInputs('advanced_ae:shattered_singularity')
+        .itemOutputs('advanced_ae:quantum_infused_dust')
+        .duration(80)
+        .EUt(ULV)
+
     // AE2 charger recipe for GT certus
     allthemods.custom({
         type: "ae2:charger",
@@ -101,35 +101,35 @@ ServerEvents.recipes(allthemods => {
         .itemOutputs('ae2:printed_logic_processor')
         .duration(80)
         .EUt(LV)
-    
+
     allthemods.recipes.gtceu.forming_press('ae2/universal/printed_logic_circuit')
         .itemInputs('minecraft:gold_ingot')
         .notConsumable('kubejs:universal_press')
         .itemOutputs('ae2:printed_logic_processor')
         .duration(80)
         .EUt(LV)
-    
+
     allthemods.recipes.gtceu.forming_press('ae2/printed_silicon_circuit')
         .itemInputs('ae2:silicon')
         .notConsumable('ae2:silicon_press')
         .itemOutputs('ae2:printed_silicon')
         .duration(80)
         .EUt(LV)
-    
+
     allthemods.recipes.gtceu.forming_press('ae2/universal/printed_silicon_circuit')
         .itemInputs('ae2:silicon')
         .notConsumable('kubejs:universal_press')
         .itemOutputs('ae2:printed_silicon')
         .duration(80)
         .EUt(LV)
-    
+
     allthemods.recipes.gtceu.forming_press('ae2/printed_engineering_circuit')
         .itemInputs('minecraft:diamond')
         .notConsumable('ae2:engineering_processor_press')
         .itemOutputs('ae2:printed_engineering_processor')
         .duration(80)
         .EUt(LV)
-    
+
     allthemods.recipes.gtceu.forming_press('ae2/universal/printed_engineering_circuit')
         .itemInputs('minecraft:diamond')
         .notConsumable('kubejs:universal_press')
@@ -143,7 +143,7 @@ ServerEvents.recipes(allthemods => {
         .itemOutputs('ae2:printed_calculation_processor')
         .duration(80)
         .EUt(LV)
-    
+
     allthemods.recipes.gtceu.forming_press('ae2/universal/printed_calculation_circuit')
         .itemInputs('ae2:certus_quartz_crystal')
         .notConsumable('kubejs:universal_press')
@@ -164,14 +164,21 @@ ServerEvents.recipes(allthemods => {
         .itemOutputs('appflux:printed_energy_processor')
         .duration(80)
         .EUt(MV)
-    
+
+    allthemods.recipes.gtceu.forming_press('aae/printed_quantum_circuit')
+        .itemInputs('advanced_ae:quantum_alloy')
+        .notConsumable('advanced_ae:quantum_processor_press')
+        .itemOutputs('advanced_ae:printed_quantum_processor')
+        .duration(80)
+        .EUt(MV)
+
     // AE2 processors in forming press
     allthemods.recipes.gtceu.forming_press('ae2/logic_circuit')
         .itemInputs(['ae2:printed_logic_processor', 'minecraft:redstone', 'ae2:printed_silicon'])
         .itemOutputs('ae2:logic_processor')
         .duration(80)
         .EUt(LV)
-    
+
     allthemods.recipes.gtceu.forming_press('ae2/engineering_circuit')
         .itemInputs(['ae2:printed_engineering_processor', 'minecraft:redstone', 'ae2:printed_silicon'])
         .itemOutputs('ae2:engineering_processor')
@@ -196,6 +203,12 @@ ServerEvents.recipes(allthemods => {
         .duration(80)
         .EUt(MV)
 
+    allthemods.recipes.gtceu.forming_press('aae/quantum_circuit')
+        .itemInputs(['advanced_ae:printed_quantum_processor', 'minecraft:redstone', 'ae2:printed_silicon'])
+        .itemOutputs('advanced_ae:quantum_processor')
+        .duration(80)
+        .EUt(MV)
+
     // ATO and vanilla silk touched ore maceration recipes
     // Minecraft stone/deepslate/nether ores
     allthemods.recipes.gtceu.macerator('macerate_iron_ore')
@@ -205,7 +218,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_iron_ore')
         .itemInputs('minecraft:deepslate_iron_ore')
         .itemOutputs('2x gtceu:crushed_iron_ore')
@@ -213,7 +226,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_coal_ore')
         .itemInputs('minecraft:coal_ore')
         .itemOutputs('4x gtceu:crushed_coal_ore')
@@ -221,7 +234,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_coal_ore')
         .itemInputs('minecraft:deepslate_coal_ore')
         .itemOutputs('4x gtceu:crushed_coal_ore')
@@ -229,7 +242,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_copper_ore')
         .itemInputs('minecraft:copper_ore')
         .itemOutputs('2x gtceu:crushed_copper_ore')
@@ -237,7 +250,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_copper_ore')
         .itemInputs('minecraft:deepslate_copper_ore')
         .itemOutputs('2x gtceu:crushed_copper_ore')
@@ -253,7 +266,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_gold_ore')
         .itemInputs('minecraft:deepslate_gold_ore')
         .itemOutputs('2x gtceu:crushed_gold_ore')
@@ -261,7 +274,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_nether_gold_ore')
         .itemInputs('minecraft:nether_gold_ore')
         .itemOutputs('4x gtceu:crushed_gold_ore')
@@ -269,7 +282,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:netherrack_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_redstone_ore')
         .itemInputs('minecraft:redstone_ore')
         .itemOutputs('10x gtceu:crushed_redstone_ore')
@@ -277,7 +290,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_redstone_ore')
         .itemInputs('minecraft:deepslate_redstone_ore')
         .itemOutputs('10x gtceu:crushed_redstone_ore')
@@ -285,7 +298,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_emerald_ore')
         .itemInputs('minecraft:emerald_ore')
         .itemOutputs('4x gtceu:crushed_emerald_ore')
@@ -293,7 +306,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_emerald_ore')
         .itemInputs('minecraft:deepslate_emerald_ore')
         .itemOutputs('4x gtceu:crushed_emerald_ore')
@@ -301,7 +314,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_lapis_ore')
         .itemInputs('minecraft:lapis_ore')
         .itemOutputs('12x gtceu:crushed_lapis_ore')
@@ -309,7 +322,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_lapis_ore')
         .itemInputs('minecraft:deepslate_lapis_ore')
         .itemOutputs('12x gtceu:crushed_lapis_ore')
@@ -317,7 +330,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_diamond_ore')
         .itemInputs('minecraft:diamond_ore')
         .itemOutputs('2x gtceu:crushed_diamond_ore')
@@ -325,7 +338,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_diamond_ore')
         .itemInputs('minecraft:deepslate_diamond_ore')
         .itemOutputs('2x gtceu:crushed_diamond_ore')
@@ -333,7 +346,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_nether_quartz_ore')
         .itemInputs('minecraft:nether_quartz_ore')
         .itemOutputs('8x gtceu:crushed_nether_quartz_ore')
@@ -349,14 +362,14 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:quartzite_gem', 1400, 850)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_other_redstone_ore')
         .itemInputs('alltheores:other_redstone_ore')
         .itemOutputs('40x gtceu:crushed_redstone_ore')
         .chancedOutput('gtceu:cinnabar_gem', 1400, 850)
         .duration(400)
         .EUt(2)
-    
+
     // ATO stone/deepslate/nether/end ores
     allthemods.recipes.gtceu.macerator('macerate_aluminum_ore')
         .itemInputs('alltheores:aluminum_ore')
@@ -365,7 +378,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_aluminum_ore')
         .itemInputs('alltheores:deepslate_aluminum_ore')
         .itemOutputs('2x gtceu:crushed_aluminium_ore')
@@ -373,7 +386,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_nether_aluminum_ore')
         .itemInputs('alltheores:nether_aluminum_ore')
         .itemOutputs('4x gtceu:crushed_aluminium_ore')
@@ -381,7 +394,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:netherrack_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_lead_ore')
         .itemInputs('alltheores:lead_ore')
         .itemOutputs('2x gtceu:crushed_lead_ore')
@@ -389,7 +402,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_lead_ore')
         .itemInputs('alltheores:deepslate_lead_ore')
         .itemOutputs('2x gtceu:crushed_lead_ore')
@@ -397,7 +410,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_nether_lead_ore')
         .itemInputs('alltheores:nether_lead_ore')
         .itemOutputs('4x gtceu:crushed_lead_ore')
@@ -413,7 +426,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_nickel_ore')
         .itemInputs('alltheores:deepslate_nickel_ore')
         .itemOutputs('2x gtceu:crushed_nickel_ore')
@@ -421,7 +434,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_nether_nickel_ore')
         .itemInputs('alltheores:nether_nickel_ore')
         .itemOutputs('4x gtceu:crushed_nickel_ore')
@@ -437,7 +450,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_platinum_ore')
         .itemInputs('alltheores:deepslate_platinum_ore')
         .itemOutputs('2x gtceu:crushed_platinum_ore')
@@ -445,7 +458,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_nether_platinum_ore')
         .itemInputs('alltheores:nether_platinum_ore')
         .itemOutputs('4x gtceu:crushed_platinum_ore')
@@ -461,7 +474,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_silver_ore')
         .itemInputs('alltheores:deepslate_silver_ore')
         .itemOutputs('2x gtceu:crushed_silver_ore')
@@ -469,7 +482,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_nether_silver_ore')
         .itemInputs('alltheores:nether_silver_ore')
         .itemOutputs('4x gtceu:crushed_silver_ore')
@@ -477,7 +490,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:netherrack_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_tin_ore')
         .itemInputs('alltheores:tin_ore')
         .itemOutputs('2x gtceu:crushed_tin_ore')
@@ -485,7 +498,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_tin_ore')
         .itemInputs('alltheores:deepslate_tin_ore')
         .itemOutputs('2x gtceu:crushed_tin_ore')
@@ -493,7 +506,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_nether_tin_ore')
         .itemInputs('alltheores:nether_tin_ore')
         .itemOutputs('4x gtceu:crushed_tin_ore')
@@ -509,7 +522,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_ruby_ore')
         .itemInputs('alltheores:deepslate_ruby_ore')
         .itemOutputs('2x gtceu:crushed_ruby_ore')
@@ -525,7 +538,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:stone_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_deepslate_sapphire_ore')
         .itemInputs('alltheores:deepslate_sapphire_ore')
         .itemOutputs('2x gtceu:crushed_sapphire_ore')
@@ -533,7 +546,7 @@ ServerEvents.recipes(allthemods => {
         .chancedOutput('gtceu:deepslate_dust', 6700, 800)
         .duration(400)
         .EUt(2)
-    
+
     allthemods.recipes.gtceu.macerator('macerate_salt_ore')
         .itemInputs('railcraft:saltpeter_ore')
         .itemOutputs('4x gtceu:crushed_salt_ore')

--- a/kubejs/server_scripts/mods/gtceu/mining_dim_ores.js
+++ b/kubejs/server_scripts/mods/gtceu/mining_dim_ores.js
@@ -3,6 +3,7 @@
 
 const $VeinedVeinGenerator = Java.loadClass('com.gregtechceu.gtceu.api.data.worldgen.generator.veins.VeinedVeinGenerator');
 const $DikeVeinGenerator = Java.loadClass('com.gregtechceu.gtceu.api.data.worldgen.generator.veins.DikeVeinGenerator');
+const $CuboidVeinGenerator = Java.loadClass('com.gregtechceu.gtceu.api.data.worldgen.generator.veins.CuboidVeinGenerator');
 
 GTCEuServerEvents.oreVeins(allthemods => {
     allthemods.modifyAll((veinId, vein) => {
@@ -36,8 +37,6 @@ GTCEuServerEvents.oreVeins(allthemods => {
             veinGen = veinGen.copy()
             veinGen.minYLevel(startY);
             veinGen.maxYLevel(endY);
-            // veinGen.minYLevel = startY;
-            // veinGen.maxYLevel = endY;
         } else if (veinGen instanceof $DikeVeinGenerator) {
             veinGen = veinGen.copy()
             veinGen.minYLevel(startY);
@@ -46,8 +45,10 @@ GTCEuServerEvents.oreVeins(allthemods => {
             blocks.forEach((block) => {
                 veinGen.withBlock(new GTDikeBlockDefinition['(com.mojang.datafixers.util.Either,int,int,int)'](block.key, block.value, startY, endY))
             })
-            // veinGen.minYLevel = startY;
-            // veinGen.maxYLevel = endY;
+        } else if (veinGen instanceof $CuboidVeinGenerator) {
+            veinGen = veinGen.copy()
+            veinGen.minY(startY)
+            veinGen.maxY(endY)
         }
 
         
@@ -56,35 +57,6 @@ GTCEuServerEvents.oreVeins(allthemods => {
         vein.dimensions('allthemodium:mining')
         vein.biomes('#allthemodium:mining_features/mining_biomes')
         vein['veinGenerator(com.gregtechceu.gtceu.api.data.worldgen.generator.VeinGenerator)'](veinGen)
-        // vein.surfaceIndicatorGenerator(indicator => indicator
-        //     .block(Block.getBlock("minecraft:air"))
-        //     .placement("above")
-        //     .density(0.4)
-        //     .radius(5))
-
-
-        // allthemods.add(veinId + '_mining', newVein => {
-        //     let veinGen = vein.veinGenerator();
-        //     if (veinGen instanceof $VeinedVeinGenerator) {
-        //         veinGen = veinGen.copy()
-        //         veinGen.minYLevel = startY;
-        //         veinGen.maxYLevel = endY;
-        //     } else if (veinGen instanceof $DikeVeinGenerator) {
-        //         veinGen = veinGen.copy()
-        //         veinGen.minYLevel = startY;
-        //         veinGen.maxYLevel = endY;
-        //     }
-
-        //     newVein.clusterSize(vein.clusterSize())
-        //     newVein.weight(vein.weight())
-        //     newVein.density(vein.density())
-        //     newVein.layer(vein.layer())
-        //     newVein.heightRangeUniform(startY, endY)
-        //     newVein.discardChanceOnAirExposure(vein.discardChanceOnAirExposure())
-        //     newVein.dimensions('allthemodium:mining')
-        //     newVein.biomes('#allthemodium:mining_features/mining_biomes')
-        //     newVein['veinGenerator(com.gregtechceu.gtceu.api.data.worldgen.generator.VeinGenerator)'](veinGen)
-        // })
     })
 
     allthemods.add("fluorite_vein", builder => {

--- a/kubejs/startup_scripts/AE2/Universal_Press.js
+++ b/kubejs/startup_scripts/AE2/Universal_Press.js
@@ -3,11 +3,24 @@
 
 StartupEvents.registry('item', allthemods => {
     allthemods
-    .create('universal_press')
-    .texture('kubejs:item/universal_press')
-    .maxStackSize(64)
-    .displayName('Universal Press');  
+        .create('universal_press')
+        .texture('kubejs:item/universal_press')
+        .maxStackSize(64)
+        .displayName('Universal Press');
+
+    allthemods
+        .create('universal_addon_press')
+        .texture('kubejs:item/universal_addon_press')
+        .maxStackSize(64)
+        .displayName('Universal Addon Press');
+
+    allthemods
+        .create('ultimate_universal_press')
+        .texture('kubejs:item/ultimate_universal_press')
+        .maxStackSize(64)
+        .displayName('Ultimate Universal Press');
 })
+
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/startup_scripts/gtceu/apiary.js
+++ b/kubejs/startup_scripts/gtceu/apiary.js
@@ -88,7 +88,7 @@ GTCEuStartupEvents.registry('gtceu:machine', allthemods => {
         .rotationState(RotationState.NON_Y_AXIS)
         .recipeType('comb_processor')
         .appearanceBlock(GTBlocks.CASING_STEEL_SOLID)
-        .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.OC_NON_PERFECT])
+        .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.OC_NON_PERFECT_SUBTICK])
         .pattern(definition => FactoryBlockPattern.start()
             .aisle('   CCC   ', '         ', '    S    ', '   SSS   ', '  SSSSS  ', '  SSSSS  ', '  SSSSS  ', '         ', '         ', '         ', '         ', '         ')
             .aisle('  CFFFC  ', '   SSS   ', '  SS SS  ', ' SS   SS ', ' S     S ', ' S     S ', ' S     S ', '         ', '         ', '         ', '         ', '         ')

--- a/kubejs/startup_scripts/gtceu/greenhouse.js
+++ b/kubejs/startup_scripts/gtceu/greenhouse.js
@@ -17,7 +17,7 @@ GTCEuStartupEvents.registry('gtceu:machine', allthemods => {
         .rotationState(RotationState.NON_Y_AXIS)
         .recipeType('greenhouse')
         .appearanceBlock(GTBlocks.CASING_STEEL_SOLID)
-        .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.OC_PERFECT])
+        .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.OC_PERFECT_SUBTICK])
         .pattern(definition => FactoryBlockPattern.start()
             .aisle('CCC', 'CCC', 'CGC', 'CGC', 'CCC')
             .aisle('CCC', 'FPF', 'G#G', 'GIG', 'CGC')


### PR DESCRIPTION
Naquadah ore and Pitchblende ore switched vein generators to a new cuboid vein generator. This adjusts our script to now account for that type of vein generator, so those ores spawn in the mining dimension correctly now.

Also added Advanced AE printed quantum circuit, quantum processor, and quantum dust recipes to the GT Forming Press and Macerator similar to other AE2 components.

Removed a redundant recipe for the UHV 16A Energy Hatch since it exists in base GT now.