### PR TITLE
Use lowercase recipe IDs for Comb Processor

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/apiary_recipes.js
+++ b/kubejs/server_scripts/mods/gtceu/apiary_recipes.js
@@ -380,7 +380,7 @@ ServerEvents.recipes(allthemods => {
             .itemInputs(inputBlock)
             .circuit(1)
 
-        let combBlockMAXRecipeBuilder = allthemods.recipes.gtceu.comb_processor(id + '_block_MAX')
+        let combBlockMAXRecipeBuilder = allthemods.recipes.gtceu.comb_processor(id + '_block_max')
             .duration(20 * 16)
             .EUt(UEV)
             .itemInputs(inputMAXBlock)


### PR DESCRIPTION
Fix Comb Processor recipe IDs to not use uppercase characters