### PR TITLE
Fixed some bugs in quests

### DIFF
--- a/config/ftbquests/quests/chapters/mystical_ag.snbt
+++ b/config/ftbquests/quests/chapters/mystical_ag.snbt
@@ -3800,7 +3800,7 @@
 				"0F031E62E5235251"
 				"67C4A4D6DD93DB0E"
 			]
-			description: ["{atm9.quest.ma.desc.atm}"]
+			description: ["{atm9.quest.ma.desc.crux}"]
 			id: "06401FE7C8D75FC1"
 			rewards: [{
 				count: 3
@@ -3879,3 +3879,4 @@
 	]
 	title: "{atm9.chapters.16.title}"
 }
+

--- a/config/ftbquests/quests/chapters/ultra_high_voltage.snbt
+++ b/config/ftbquests/quests/chapters/ultra_high_voltage.snbt
@@ -1369,7 +1369,7 @@
 				""
 				"{atm9.quest.gregtech.uhv.desc.hrmbs2}"
 				""
-				"{atm9.quest.gregtech.uhv.desc.hrmbs2}"
+				"{atm9.quest.gregtech.uhv.desc.hrmbs3}"
 			]
 			id: "7CF668319F4B5E11"
 			shape: "gear"
@@ -1462,3 +1462,4 @@
 	]
 	title: "{atm9.chapters.35.title}"
 }
+


### PR DESCRIPTION
You can see bugs at the screenshots below.
<img width="495" height="363" alt="image" src="https://github.com/user-attachments/assets/8833eed1-c038-4264-995f-650ac0e418b3" />
*Line "Time for an upgrade..." is duplicated*
<img width="417" height="160" alt="image" src="https://github.com/user-attachments/assets/51e6026c-2cf5-4de5-bbbf-219c3ff77d0c" />
*"atm9.quest.ma.desc.atm" is shown instead of actual description*

After these commits, it looks like this:

<img width="487" height="366" alt="image" src="https://github.com/user-attachments/assets/a82176ac-053e-48a1-9c05-4d7e40740d1f" />
<img width="419" height="166" alt="image" src="https://github.com/user-attachments/assets/ca1df132-d539-4479-a3eb-3b10750d0abf" />
